### PR TITLE
Add typer to manage command line arguments and output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     install_requires=[
         "agithub",
         "scancode-toolkit",
+        "typer",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
We are going to keep adding CLI options and we should use a modern library for args parsing and terminal output.

This PR adds `typer` to deal with arguments and CLI output.