### PR TITLE
Fix for failures in the CLI after all components recent adjustments.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,10 +11,10 @@
             "program": "${file}",
             "console": "integratedTerminal",
             "args": [
-                // "https://github.com/DataDog/stratus-red-team",
+                "https://github.com/DataDog/stratus-red-team",
                 // "https://github.com/DataDog/dd-trace-go",
                 // "https://github.com/DataDog/datadog-agent",
-                "https://github.com/DataDog/ospo-tools",
+                // "https://github.com/DataDog/ospo-tools",
             ],
             "env": {
                 // Set the GITHUB_TOKEN environment variable before opening vscode. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,15 @@ warn_unused_ignores = "True"
 warn_redundant_casts = "True"
 
 [[tool.mypy.overrides]]
+module = "scancode.api"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "scancode"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "scancode.api"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/ospo_tools/metadata_collector/strategies/github_repository_collection_strategy.py
+++ b/src/ospo_tools/metadata_collector/strategies/github_repository_collection_strategy.py
@@ -30,6 +30,8 @@ class GitHubRepositoryMetadataCollectionStrategy(MetadataCollectionStrategy):
                         package.license = repository["license"].get("spdx_id", None)
                         if package.license == "NOASSERTION":
                             package.license = None
+                elif status == 301:
+                    continue  # repository moved but we not supporting redirects here yet
                 else:
                     raise ValueError(
                         f"Failed to get repository information for {owner}/{repo}"

--- a/src/ospo_tools/metadata_collector/strategies/scan_code_toolkit_metadata_collection_strategy.py
+++ b/src/ospo_tools/metadata_collector/strategies/scan_code_toolkit_metadata_collection_strategy.py
@@ -3,7 +3,7 @@ import tempfile
 import os
 from shlex import quote
 from typing import Iterator
-import scancode
+import scancode.api
 
 
 from ospo_tools.metadata_collector.metadata import Metadata
@@ -33,13 +33,11 @@ class ScanCodeToolkitMetadataCollectionStrategy(MetadataCollectionStrategy):
         # in the temporary directory make a shallow clone of the repository
         self.temp_dir_name = self.temp_dir.name
         # save the source files lists
-        if not license_source_files:
-            license_source_files = []
-        else:
+        self.license_source_files: list[str] | None = None
+        if license_source_files is not None:
             self.license_source_files = [file.lower() for file in license_source_files]
-        if not copyright_source_files:
-            self.copyright_source_files = []
-        else:
+        self.copyright_source_files: list[str] | None = None
+        if copyright_source_files is not None:
             self.copyright_source_files = [
                 file.lower() for file in copyright_source_files
             ]
@@ -56,6 +54,8 @@ class ScanCodeToolkitMetadataCollectionStrategy(MetadataCollectionStrategy):
                 updated_metadata.append(package)
                 continue
             # otherwise we make a shallow clone of the repository
+            if not package.origin and package.name is not None:
+                package.origin = package.name
             owner, repo = self.purl_parser.get_github_owner_and_repo(package.origin)
             # if not github repository available, we skip for now
             if owner is None or repo is None:

--- a/tests/unit/test_go_licenses_collection_strategy.py
+++ b/tests/unit/test_go_licenses_collection_strategy.py
@@ -19,8 +19,7 @@ def test_go_licenses_collection_strategy_clones_and_run_go_license_on_init(mocke
         return_value=purl_parser_object,
     )
     temp_dir_object = mocker.Mock()
-    temp_dir_object.name = "test_temp_dir"
-    temp_dir_object.__enter__ = mocker.Mock(return_value=temp_dir_object)
+    temp_dir_object.__enter__ = mocker.Mock(return_value="test_temp_dir")
     temp_dir_object.__exit__ = mocker.Mock(return_value=None)
     temp_dir_mock = mocker.patch(
         "tempfile.TemporaryDirectory", return_value=temp_dir_object
@@ -71,8 +70,7 @@ def test_go_licenses_collection_strategy_failing_clone_raises_exception(mocker):
         return_value=purl_parser_object,
     )
     temp_dir_object = mocker.Mock()
-    temp_dir_object.name = "test_temp_dir"
-    temp_dir_object.__enter__ = mocker.Mock(return_value=temp_dir_object)
+    temp_dir_object.__enter__ = mocker.Mock(return_value="test_temp_dir")
     temp_dir_object.__exit__ = mocker.Mock(return_value=None)
     temp_dir_mock = mocker.patch(
         "tempfile.TemporaryDirectory", return_value=temp_dir_object
@@ -94,8 +92,7 @@ def test_go_licenses_collection_strategy_do_not_miss_or_replace_non_go_packages(
         return_value=purl_parser_object,
     )
     temp_dir_object = mocker.Mock()
-    temp_dir_object.name = "test_temp_dir"
-    temp_dir_object.__enter__ = mocker.Mock(return_value=temp_dir_object)
+    temp_dir_object.__enter__ = mocker.Mock(return_value="test_temp_dir")
     temp_dir_object.__exit__ = mocker.Mock(return_value=None)
     mocker.patch("tempfile.TemporaryDirectory", return_value=temp_dir_object)
 


### PR DESCRIPTION
Added argument  --enable-deep-scan that defaults to false. 
A few bug adjustments. 

Output of the run without deep-scan on red-stratus-team:
```
"component","origin","license","copyright"
"github.com/hashicorp/go-cleanhttp","github.com/hashicorp/go-cleanhttp","MPL-2.0","hashicorp"
"github.com/hashicorp/go-version","github.com/hashicorp/go-version","MPL-2.0","hashicorp"
"golang.org/x/text","golang.org/x/text","",""
"github.com/golang/snappy","github.com/golang/snappy","BSD-3-Clause","golang"
"github.com/google/uuid","github.com/google/uuid","BSD-3-Clause","google"
"golang.org/x/net","golang.org/x/net","",""
"github.com/davecgh/go-spew","github.com/davecgh/go-spew","ISC","davecgh"
"github.com/gogo/protobuf","github.com/gogo/protobuf","BSD-3-Clause","gogo"
"github.com/jmespath/go-jmespath","github.com/jmespath/go-jmespath","Apache-2.0","James Saryerwinnie"
"github.com/spf13/pflag","github.com/spf13/pflag","BSD-3-Clause","spf13"
"gopkg.in/yaml.v2","gopkg.in/yaml.v2","",""
"gopkg.in/yaml.v3","gopkg.in/yaml.v3","",""
"github.com/go-logr/logr","github.com/go-logr/logr","Apache-2.0","go-logr"
"github.com/json-iterator/go","github.com/json-iterator/go","MIT","json-iterator"
"github.com/modern-go/concurrent","github.com/modern-go/concurrent","Apache-2.0","modern-go"
"github.com/modern-go/reflect2","github.com/modern-go/reflect2","Apache-2.0","modern-go"
"google.golang.org/appengine","google.golang.org/appengine","",""
"github.com/golang-jwt/jwt","github.com/golang-jwt/jwt","MIT","golang-jwt"
"github.com/kylelemons/godebug","github.com/kylelemons/godebug","Apache-2.0","kylelemons"
"github.com/moby/spdystream","github.com/moby/spdystream","Apache-2.0","Docker Inc."
"gopkg.in/inf.v0","gopkg.in/inf.v0","",""
"github.com/golang/protobuf","github.com/golang/protobuf","BSD-3-Clause","the Go contributors"
"google.golang.org/protobuf","google.golang.org/protobuf","",""
"sigs.k8s.io/structured-merge-diff/v4","sigs.k8s.io/structured-merge-diff/v4","",""
"sigs.k8s.io/json","sigs.k8s.io/json","",""
"github.com/google/gofuzz","github.com/google/gofuzz","Apache-2.0","google"
"golang.org/x/time","golang.org/x/time","",""
"github.com/pkg/browser","github.com/pkg/browser","BSD-2-Clause","pkg"
"sigs.k8s.io/yaml","sigs.k8s.io/yaml","",""
"github.com/google/go-cmp","github.com/google/go-cmp","BSD-3-Clause","google"
"k8s.io/apimachinery","k8s.io/apimachinery","",""
"k8s.io/utils","k8s.io/utils","",""
"k8s.io/kube-openapi","k8s.io/kube-openapi","",""
"github.com/zclconf/go-cty","github.com/zclconf/go-cty","MIT","zclconf"
"k8s.io/klog/v2","k8s.io/klog/v2","",""
"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute","github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute","MIT","Microsoft Corporation, Kale Blankenship"
"github.com/hashicorp/hc-install","github.com/hashicorp/hc-install","MPL-2.0","hashicorp"
"github.com/hashicorp/terraform-exec","github.com/hashicorp/terraform-exec","MPL-2.0","hashicorp"
"github.com/hashicorp/terraform-json","github.com/hashicorp/terraform-json","MPL-2.0","hashicorp"
"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources","github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources","MPL-2.0","Azure"
"k8s.io/client-go","k8s.io/client-go","",""
"github.com/Azure/azure-sdk-for-go/sdk/azidentity","github.com/Azure/azure-sdk-for-go/sdk/azidentity","MPL-2.0","Azure"
"github.com/AzureAD/microsoft-authentication-library-for-go","github.com/AzureAD/microsoft-authentication-library-for-go","MIT","AzureAD"
"github.com/Azure/azure-sdk-for-go/sdk/internal","github.com/Azure/azure-sdk-for-go/sdk/internal","MIT","Azure"
"k8s.io/api","k8s.io/api","",""
"golang.org/x/oauth2","golang.org/x/oauth2","",""
"github.com/Azure/azure-sdk-for-go/sdk/azcore","github.com/Azure/azure-sdk-for-go/sdk/azcore","MIT","Azure"
"github.com/datadog/stratus-red-team/v2","github.com/datadog/stratus-red-team/v2","Apache-2.0","Datadog, Inc."
"golang.org/x/crypto","golang.org/x/crypto","",""
"golang.org/x/sys","golang.org/x/sys","",""
"golang.org/x/term","golang.org/x/term","",""
"github.com/aws/smithy-go","github.com/aws/smithy-go","Apache-2.0","Amazon.com, Inc. or its affiliates"
"github.com/aws/aws-sdk-go-v2/internal/ini","github.com/aws/aws-sdk-go-v2/internal/ini","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding","github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream","github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/internal/presigned-url","github.com/aws/aws-sdk-go-v2/service/internal/presigned-url","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/internal/s3shared","github.com/aws/aws-sdk-go-v2/service/internal/s3shared","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/s3","github.com/aws/aws-sdk-go-v2/service/s3","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/sts","github.com/aws/aws-sdk-go-v2/service/sts","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/config","github.com/aws/aws-sdk-go-v2/config","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/credentials","github.com/aws/aws-sdk-go-v2/credentials","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/feature/ec2/imds","github.com/aws/aws-sdk-go-v2/feature/ec2/imds","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/sso","github.com/aws/aws-sdk-go-v2/service/sso","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/ec2","github.com/aws/aws-sdk-go-v2/service/ec2","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/secretsmanager","github.com/aws/aws-sdk-go-v2/service/secretsmanager","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/ssm","github.com/aws/aws-sdk-go-v2/service/ssm","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/rds","github.com/aws/aws-sdk-go-v2/service/rds","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/lambda","github.com/aws/aws-sdk-go-v2/service/lambda","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2","github.com/aws/aws-sdk-go-v2","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/internal/configsources","github.com/aws/aws-sdk-go-v2/internal/configsources","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/internal/endpoints/v2","github.com/aws/aws-sdk-go-v2/internal/endpoints/v2","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/cloudtrail","github.com/aws/aws-sdk-go-v2/service/cloudtrail","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/organizations","github.com/aws/aws-sdk-go-v2/service/organizations","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/iam","github.com/aws/aws-sdk-go-v2/service/iam","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/aws/aws-sdk-go-v2/service/rolesanywhere","github.com/aws/aws-sdk-go-v2/service/rolesanywhere","Apache-2.0","Amazon.com, Inc. or its affiliates, Stripe, Inc."
"github.com/DataDog/datadog-api-client-go","github.com/DataDog/datadog-api-client-go","Apache-2.0","Datadog, Inc."
"github.com/DataDog/zstd","github.com/DataDog/zstd","BSD-3-Clause, BSD-2-Clause","DataDog"
"github.com/mattn/go-colorable","github.com/mattn/go-colorable","MIT","mattn"
"github.com/josharian/intern","github.com/josharian/intern","MIT","josharian"
"github.com/go-logr/stdr","github.com/go-logr/stdr","Apache-2.0","go-logr"
"github.com/golang/groupcache","github.com/golang/groupcache","Apache-2.0","golang"
"github.com/mattn/go-runewidth","github.com/mattn/go-runewidth","MIT","mattn"
"github.com/pmezard/go-difflib","github.com/pmezard/go-difflib","BSD-3-Clause","pmezard"
"github.com/rivo/uniseg","github.com/rivo/uniseg","MIT","rivo"
"github.com/cenkalti/backoff/v4","github.com/cenkalti/backoff/v4","MIT","cenkalti"
"github.com/PuerkitoBio/purell","github.com/PuerkitoBio/purell","BSD-3-Clause","PuerkitoBio"
"github.com/PuerkitoBio/urlesc","github.com/PuerkitoBio/urlesc","BSD-3-Clause","PuerkitoBio"
"github.com/go-openapi/jsonpointer","github.com/go-openapi/jsonpointer","Apache-2.0","go-openapi"
"github.com/mailru/easyjson","github.com/mailru/easyjson","MIT","mailru"
"github.com/munnerz/goautoneg","github.com/munnerz/goautoneg","BSD-3-Clause","munnerz"
"github.com/mattn/go-isatty","github.com/mattn/go-isatty","MIT","mattn"
"github.com/google/gnostic","github.com/google/gnostic","Apache-2.0","google"
"github.com/fatih/color","github.com/fatih/color","MIT","fatih"
"github.com/cjlapao/common-go","github.com/cjlapao/common-go","MIT","cjlapao"
"github.com/microsoft/kiota-serialization-form-go","github.com/microsoft/kiota-serialization-form-go","MIT","microsoft"
"github.com/microsoft/kiota-serialization-multipart-go","github.com/microsoft/kiota-serialization-multipart-go","MIT","microsoft"
"github.com/microsoft/kiota-serialization-text-go","github.com/microsoft/kiota-serialization-text-go","MIT","microsoft"
"github.com/inconshreveable/mousetrap","github.com/inconshreveable/mousetrap","Apache-2.0","inconshreveable"
"go.opencensus.io","go.opencensus.io","",""
"github.com/spf13/cobra","github.com/spf13/cobra","Apache-2.0","spf13"
"github.com/go-openapi/jsonreference","github.com/go-openapi/jsonreference","Apache-2.0","go-openapi"
"github.com/go-openapi/swag","github.com/go-openapi/swag","Apache-2.0","go-openapi"
"github.com/emicklei/go-restful/v3","github.com/emicklei/go-restful/v3","MIT","emicklei"
"github.com/Microsoft/go-winio","github.com/Microsoft/go-winio","MIT","microsoft"
"google.golang.org/grpc","google.golang.org/grpc","",""
"github.com/googleapis/enterprise-certificate-proxy","github.com/googleapis/enterprise-certificate-proxy","Apache-2.0","googleapis"
"google.golang.org/genproto","google.golang.org/genproto","",""
"cloud.google.com/go/compute","cloud.google.com/go/compute","",""
"github.com/googleapis/gax-go/v2","github.com/googleapis/gax-go/v2","BSD-3-Clause","googleapis"
"github.com/jedib0t/go-pretty/v6","github.com/jedib0t/go-pretty/v6","MIT","jedib0t"
"github.com/aws/aws-sdk-go-v2/service/ssooidc","github.com/aws/aws-sdk-go-v2/service/ssooidc","MIT","aws"
"github.com/aws/aws-sdk-go-v2/feature/s3/manager","github.com/aws/aws-sdk-go-v2/feature/s3/manager","MIT","aws"
"github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect","github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect","MIT","aws"
"google.golang.org/api","google.golang.org/api","",""
"github.com/aws/aws-sdk-go-v2/service/route53resolver","github.com/aws/aws-sdk-go-v2/service/route53resolver","MIT","aws"
"go.opentelemetry.io/otel","go.opentelemetry.io/otel","",""
"go.opentelemetry.io/otel/metric","go.opentelemetry.io/otel/metric","",""
"go.opentelemetry.io/otel/trace","go.opentelemetry.io/otel/trace","",""
"github.com/stretchr/testify","github.com/stretchr/testify","MIT","stretchr"
"github.com/stretchr/objx","github.com/stretchr/objx","MIT","stretchr"
"github.com/golang-jwt/jwt/v5","github.com/golang-jwt/jwt/v5","MIT","golang-jwt"
"github.com/aws/aws-sdk-go-v2/service/ses","github.com/aws/aws-sdk-go-v2/service/ses","MIT","aws"
"github.com/std-uritemplate/std-uritemplate/go","github.com/std-uritemplate/std-uritemplate/go","Apache-2.0","std-uritemplate"
"github.com/aws/aws-sdk-go-v2/service/eks","github.com/aws/aws-sdk-go-v2/service/eks","Apache-2.0","aws"
"github.com/microsoftgraph/msgraph-sdk-go","github.com/microsoftgraph/msgraph-sdk-go","MIT","microsoftgraph"
"github.com/microsoft/kiota-authentication-azure-go","github.com/microsoft/kiota-authentication-azure-go","MIT","microsoft"
"github.com/microsoft/kiota-http-go","github.com/microsoft/kiota-http-go","MIT","microsoft"
"github.com/microsoft/kiota-serialization-json-go","github.com/microsoft/kiota-serialization-json-go","MIT","microsoft"
"github.com/microsoftgraph/msgraph-sdk-go-core","github.com/microsoftgraph/msgraph-sdk-go-core","MIT","microsoftgraph"
"github.com/microsoft/kiota-abstractions-go","github.com/microsoft/kiota-abstractions-go","MIT","microsoft"
"github.com/microsoftgraph/msgraph-beta-sdk-go","github.com/microsoftgraph/msgraph-beta-sdk-go","MIT","microsoftgraph"
"github.com/aws/aws-sdk-go-v2/service/bedrockruntime","github.com/aws/aws-sdk-go-v2/service/bedrockruntime","MIT","aws"
"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6","github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6","MIT","Azure"
"github.com/aws/aws-sdk-go-v2/internal/v4a","github.com/aws/aws-sdk-go-v2/internal/v4a","MIT","aws"
"github.com/aws/aws-sdk-go-v2/service/internal/checksum","github.com/aws/aws-sdk-go-v2/service/internal/checksum","MIT","aws"
"docker/login-action","docker/login-action","",""
"docker/build-push-action","docker/build-push-action","",""
"step-security/harden-runner","step-security/harden-runner","",""
"goreleaser/goreleaser-action","goreleaser/goreleaser-action","",""
"ossf/scorecard-action","ossf/scorecard-action","",""
"github/codeql-action/upload-sarif","github/codeql-action/upload-sarif","",""
"dominikh/staticcheck-action","dominikh/staticcheck-action","",""
"hashicorp/setup-terraform","hashicorp/setup-terraform","",""
"com.github.DataDog/stratus-red-team","git+https://github.com/DataDog/stratus-red-team","Apache-2.0","DataDog"
```

The run with deep-scan on is still taking hours, we will need to further optimize to make it usable in daily setups. 