### PR TITLE
[BUG FIX] Update dest_path even if it exists

### DIFF
--- a/src/ospo_tools/metadata_collector/strategies/scan_code_toolkit_metadata_collection_strategy.py
+++ b/src/ospo_tools/metadata_collector/strategies/scan_code_toolkit_metadata_collection_strategy.py
@@ -17,6 +17,10 @@ def list_dir(dest_path: str) -> list[str]:
     return os.listdir(dest_path)
 
 
+def path_exists(file_path: str) -> bool:
+    return os.path.exists(file_path)
+
+
 def walk_directory(dest_path: str) -> Iterator[tuple[str, list[str], list[str]]]:
     return os.walk(dest_path)
 
@@ -65,7 +69,7 @@ class ScanCodeToolkitMetadataCollectionStrategy(MetadataCollectionStrategy):
             repository_url = f"https://github.com/{owner}/{repo}"
             # some repositories provide more than one package, if already cloned, we skip
             dest_path = f"{self.temp_dir_name}/{owner}-{repo}"
-            if not os.path.exists(dest_path):
+            if not path_exists(dest_path):
                 result = os.system(
                     "git clone --depth 1 {} {}".format(
                         quote(repository_url), quote(dest_path)


### PR DESCRIPTION
Right now, we only update `dest_path` if we have never cloned the repo before, but we use that variable later on to find the licenses and copyrights.

This means that if we have cloned the repo before, we don't update the path, so we may be using a different cloned repo to find licenses, translating into wrong copyright and licenses.

This PR fixes this scenario, by updating the `dest_path` before checking for existance.

[UPDATE] Added test that reproduces the bug in the old code and passes after the fix. 