### PR TITLE
Avoid running the scancode strategy twice with deep-scanning

### DIFF
--- a/src/ospo_tools/cli/generate_3rd_party_csv.py
+++ b/src/ospo_tools/cli/generate_3rd_party_csv.py
@@ -128,14 +128,15 @@ def main(
         strategies.append(GoLicensesMetadataCollectionStrategy(go_licenses_report_hint))
 
     if enabled_strategies["ScanCodeToolkitMetadataCollectionStrategy"]:
-        strategies.append(
-            ScanCodeToolkitMetadataCollectionStrategy(
-                cli_config.default_config.preset_license_file_locations,
-                cli_config.default_config.preset_copyright_file_locations,
-            )
-        )
         if deep_scanning:
             strategies.append(ScanCodeToolkitMetadataCollectionStrategy())
+        else:
+            strategies.append(
+                ScanCodeToolkitMetadataCollectionStrategy(
+                    cli_config.default_config.preset_license_file_locations,
+                    cli_config.default_config.preset_copyright_file_locations,
+                )
+            )
 
     if enabled_strategies["GitHubRepositoryMetadataCollectionStrategy"]:
         strategies.append(GitHubRepositoryMetadataCollectionStrategy(github_client))


### PR DESCRIPTION
Right now, if the tool is run with the `--deep-scanning` parameter, we ran the code scan strategy twice, one in shallow mode, one in deep mode, which already contains the shallow mode.

We should avoid duplicating efforts by avoiding running shallow mode if we are going to run deep mode nevertheless