### PR TITLE
Adding integration test with stratus-red-team

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,12 +17,19 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b #v5.3.0
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: "3.13"
 
+      - name: Set up Golang
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # 5.1.0
+        with:
+          go-version: "1.23"
+
       - name: Install dependencies
         run: |
+          go install github.com/google/go-licenses@latest
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
           python -m venv venv
           source venv/bin/activate
           python -m pip install --upgrade pip
@@ -33,7 +40,16 @@ jobs:
           source venv/bin/activate
           venv/bin/generate_3rd_party_csv --help
 
-      - name: Run the generate_third_party_cli.py script against the Stratus Red Team repository
+      - name: Run the generate_third_party_cli.py script against the Stratus Red Team repository only for root (quick fail)
         run: |
           source venv/bin/activate 
           venv/bin/generate_3rd_party_csv --only-root-project https://github.com/DataDog/stratus-red-team
+
+      - name: Run the generate_third_party_cli.py script against the Stratus Red Team repository only for root
+        run: |
+          git clone https://github.com/DataDog/stratus-red-team /tmp/stratus-red-team
+          cd /tmp/stratus-red-team/v2
+          $(go env GOPATH)/bin/go-licenses report ./... > /tmp/srt.licenses
+          cd -
+          source venv/bin/activate 
+          venv/bin/generate_3rd_party_csv --go-licenses-csv-file=/tmp/srt.licenses https://github.com/DataDog/stratus-red-team


### PR DESCRIPTION
Adding a test that takes full run of a project with all strategies. Using the golang licenses, this package should take only a few minutes to complete the run. 
Right now, we don't know what will be the final valid output, but once stabilizing we should check it is matched. 
For now we validate that the run can be done and completed without errors.