### PR TITLE
Making integ test to running in a user-like env

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.10"
 
       - name: Set up Golang
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # 5.1.0
@@ -30,20 +30,16 @@ jobs:
         run: |
           go install github.com/google/go-licenses@latest
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-          python -m venv venv
-          source venv/bin/activate
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          python -m pip install .
 
       - name: Run the generate_third_party_cli.py script with the --help flag
         run: |
-          source venv/bin/activate
-          venv/bin/get-licenses-copyrights --help
+          get-licenses-copyrights --help
 
       - name: Run the generate_third_party_cli.py script against the Stratus Red Team repository only for root (quick fail)
         run: |
-          source venv/bin/activate 
-          venv/bin/get-licenses-copyrights --only-root-project https://github.com/DataDog/stratus-red-team
+          get-licenses-copyrights --only-root-project https://github.com/DataDog/stratus-red-team
 
       - name: Run the generate_third_party_cli.py script against the Stratus Red Team repository only for root
         run: |
@@ -51,5 +47,4 @@ jobs:
           cd /tmp/stratus-red-team/v2
           $(go env GOPATH)/bin/go-licenses report ./... > /tmp/srt.licenses
           cd -
-          source venv/bin/activate 
-          venv/bin/get-licenses-copyrights --go-licenses-csv-file=/tmp/srt.licenses https://github.com/DataDog/stratus-red-team
+          get-licenses-copyrights --go-licenses-csv-file=/tmp/srt.licenses https://github.com/DataDog/stratus-red-team

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Because, these tools require calls to public APIs, and the APIs may trottle down
 
 ### requirements
 
-- python3.9+ (in MacOS 15+ comes preinstalled) - [Python install instructions](https://www.python.org/downloads/)
+- python3.10+ - [Python install instructions](https://www.python.org/downloads/)
 - gopkg - [GoLang and GoPkg install instructions](https://go.dev/doc/install)
 - go-licenses - [GoLicenses install instructions](https://github.com/google/go-licenses?tab=readme-ov-file#installation)
 - libmagic (only on mac):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ospo-tools"
 version = "0.1.0"
 description = "A set of tools to help with the OSPO activities and reporting"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Damian Vicino", email = "damian.vicino@datadoghq.com" },
     { name = "Ara Pulido", email = "ara.pulido@datadoghq.com" }


### PR DESCRIPTION
Made integration test to resemble closer to what final users do. 
- Install globally, not into a virtualenv
- Run the test on Python minimal required version in place of some newer version.
- Adjusted minimal required version to 3.10., 3.9 would work only for intel based instances because one of our deep transitive dependencies. (beautifulsoup4)