### PR TITLE
Add a specific error for tokens without enough permissions

### DIFF
--- a/src/ospo_tools/artifact_management/source_code_manager.py
+++ b/src/ospo_tools/artifact_management/source_code_manager.py
@@ -22,6 +22,12 @@ class NonAccessibleRepository(Exception):
     pass
 
 
+class UnauthorizedRepository(Exception):
+    """Exception raised when the GitHub token doesn't have enough permissions."""
+
+    pass
+
+
 def extract_ref(ref: str, url: str) -> str:
     split_ref = ref.split("/")
     for i in range(len(split_ref)):

--- a/src/ospo_tools/cli/get_licenses_copyrights.py
+++ b/src/ospo_tools/cli/get_licenses_copyrights.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from ospo_tools.artifact_management.source_code_manager import (
     NonAccessibleRepository,
     SourceCodeManager,
+    UnauthorizedRepository,
 )
 from ospo_tools.artifact_management.artifact_manager import validate_cache_dir
 from ospo_tools.metadata_collector import MetadataCollector
@@ -319,7 +320,7 @@ def main(
     metadata_collector = MetadataCollector(strategies)
     try:
         metadata = metadata_collector.collect_metadata(package)
-    except NonAccessibleRepository as e:
+    except (NonAccessibleRepository, UnauthorizedRepository) as e:
         print(f"\033[91m{e}\033[0m", file=sys.stderr)
         exit(1)
 

--- a/src/ospo_tools/metadata_collector/strategies/github_sbom_collection_strategy.py
+++ b/src/ospo_tools/metadata_collector/strategies/github_sbom_collection_strategy.py
@@ -9,7 +9,10 @@ __all__ = ["GitHubSbomMetadataCollectionStrategy", "ProjectScope"]
 from agithub.GitHub import GitHub
 from typing import Any
 from giturlparse import parse as parse_git_url
-from ospo_tools.artifact_management.source_code_manager import NonAccessibleRepository
+from ospo_tools.artifact_management.source_code_manager import (
+    NonAccessibleRepository,
+    UnauthorizedRepository,
+)
 
 
 class GitHubSbomMetadataCollectionStrategy(MetadataCollectionStrategy):
@@ -159,8 +162,14 @@ class GitHubSbomMetadataCollectionStrategy(MetadataCollectionStrategy):
             return result["sbom"]
         if status == 404:
             error_message = (
-                f"Inexistent repository or private repository and lack of permissions in GH_TOKEN passed.\n"
-                f"If {owner}/{repo} is a valid repository, please check if the token has content-read and metadata-read required permissions."
+                f"Inexistent repository or private repository and not enough permissions in the GitHub token.\n"
+                f"If {owner}/{repo} is a valid repository, check if the token has the content-read and metadata-read required permissions."
             )
             raise NonAccessibleRepository(error_message)
+        if status == 401:
+            error_message = (
+                f"The GitHub token doesn't have enough permissions to access the {owner}/{repo} repository.\n"
+                f"Check if the token has the content-read and metadata-read required permissions."
+            )
+            raise UnauthorizedRepository(error_message)
         raise ValueError(f"Failed to get SBOM for {owner}/{repo}")

--- a/tests/unit/test_github_sbom_collection_strategy.py
+++ b/tests/unit/test_github_sbom_collection_strategy.py
@@ -1,6 +1,9 @@
 from unittest.mock import call
 import pytest
-from ospo_tools.artifact_management.source_code_manager import NonAccessibleRepository
+from ospo_tools.artifact_management.source_code_manager import (
+    NonAccessibleRepository,
+    UnauthorizedRepository,
+)
 from ospo_tools.metadata_collector.metadata import Metadata
 from ospo_tools.metadata_collector.strategies.github_sbom_collection_strategy import (
     GitHubSbomMetadataCollectionStrategy,
@@ -143,6 +146,46 @@ def test_github_sbom_collection_strategy_raise_special_exception_if_error_callin
     ]
 
     with pytest.raises(NonAccessibleRepository, match=".*test_owner/test_repo.*"):
+        strategy.augment_metadata(initial_metadata)
+
+    github_parse_mock.assert_called_once_with("test_purl")
+    sbom_mock.get.assert_called_once_with()
+
+
+def test_github_sbom_collection_strategy_raise_special_exception_if_error_calling_github_sbom_api_is_401(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    sbom_mock = mocker.Mock()
+    sbom_mock.get.return_value = (401, "Unauthorized")
+    github_client_mock = GitHubClientMock(sbom_input=SbomMockWrapper(sbom_mock))
+
+    github_parse_mock = mocker.patch(
+        "ospo_tools.metadata_collector.strategies.github_sbom_collection_strategy.parse_git_url",
+        return_value=GitUrlParseMock(
+            valid=True,
+            platform="github",
+            owner="test_owner",
+            repo="test_repo",
+        ),
+    )
+
+    strategy = GitHubSbomMetadataCollectionStrategy(
+        github_client=github_client_mock,
+        project_scope=ProjectScope.ALL,
+    )
+
+    initial_metadata = [
+        Metadata(
+            name="",
+            version="",
+            origin="test_purl",
+            local_src_path="",
+            license=[],
+            copyright=[],
+        )
+    ]
+
+    with pytest.raises(UnauthorizedRepository, match=".*test_owner/test_repo.*"):
         strategy.augment_metadata(initial_metadata)
 
     github_parse_mock.assert_called_once_with("test_purl")


### PR DESCRIPTION
If you create a GitHub token without enough permissions (or you copy the token incorrectly), the GitHub API will return a `401` error.

This PR adds a specific error when that happens.