### PR TITLE
[OSPO-196] Improve CLI UX 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ CI runs the contract tests before attempting to run the unit tests.
 
 - Initial set of dependencies is collected via github-sbom api, gopkg listing, and PyPI.
 - Action packages are ignored.
-- Python usage of PyPI metadata is limited to pure Python projects. If there are native dependencies or out-of-pypi requirements, failures are expected. The usage of the PyPI strategy can be disabled in those cases, but will reduce they coverage of the tool.
+- Python usage of PyPI metadata is limited to pure Python projects. If there are native dependencies or out-of-pypi requirements, failures are expected. The usage of the PyPI strategy can be disabled in those cases, but will reduce the coverage of the tool.

--- a/src/ospo_tools/cli/get_licenses_copyrights.py
+++ b/src/ospo_tools/cli/get_licenses_copyrights.py
@@ -198,7 +198,7 @@ def main(
     skip_pypi: Annotated[
         bool,
         typer.Option(
-            "--skip-pypi-strategy",
+            "--no-pypi-strategy",
             help="Skip the PyPI collection strategy.",
             rich_help_panel="Scanning Options",
         ),
@@ -206,7 +206,7 @@ def main(
     skip_gopkg: Annotated[
         bool,
         typer.Option(
-            "--skip-gopkg-strategy",
+            "--no-gopkg-strategy",
             help="Skip the GoPkg collection strategy.",
             rich_help_panel="Scanning Options",
         ),


### PR DESCRIPTION
Some changes here (this PR can be reviewed per each commit if needed):

* Added two new options to optionally skip the PyPI and the GoPkg strategies
* Group options in categories, to help reading the `--help` output
* Remove autocompletion options for now. We can always re-add when the tool is more complex
