### PR TITLE
Bug fix for pypi returning dependency with None as project-urls

### DIFF
--- a/src/dd_license_attribution/metadata_collector/strategies/pypi_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/pypi_collection_strategy.py
@@ -52,6 +52,8 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
         if dependencies is None:
             return updated_metadata
         for dependency, version in dependencies:
+            logging.debug(f"dependency: {dependency}, version: {version}")
+
             # get the metadata from pypi API
             pypi_metadata = self._get_metadata_from_pypi(dependency, version)
             if pypi_metadata is None:
@@ -61,10 +63,13 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
             else:
                 pypi_info = {"name": dependency}
 
+            logging.debug(f"pypi_info: {pypi_info}")
+            logging.debug(f"pypi_metadata: {pypi_metadata}")
+
             origin = "pypi:" + dependency
             project_urls = {}
             # Depending on the pypi package, the GitHub URL is in different keys
-            if "project_urls" in pypi_info:
+            if "project_urls" in pypi_info and pypi_info["project_urls"] is not None:
                 project_urls = pypi_info["project_urls"]
 
             for key in project_urls:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

We recently found a dependency in a project that when its metadata is pulled from Pypi the "project_urls" key is defined, but its value set to None. In the past we saw it undefined, or set to an array (potentially empty) of strings.

Added to the decondition checking if project_urls is defined a check for its value to be not None before assigning. 

I also added 3 log lines in DEBUG level that were help to diagnose this issue. 

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing
Run against a repository that is python and has dependency on "pipy:decorator" package.
<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
