### PR TITLE
[OSPO-261] Add an option to skip the GitHub SBOM strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `--use-mirrors` parameter to support alternative repository URLs for source code fetching
 - Support for reference mapping for mirror declarations
+- `--no-github-sbom-strategy` parameter to skip the GitHub SBOM strategy
 
 ### Changed
 - Improved PyPI strategy metadata extraction

--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ The following optional parameters are available:
 - `--only-root-project`: Extracts information from the licenses and copyright of the passed package, not its dependencies.
 
 ##### Strategy Selection
-- `--deep-scanning`: Enables intensive source code analysis using [scancode-toolkit](). This will parse license and copyright information from full package source code. Note: This is a resource-intensive task that may take hours or days to process depending on package size.
-- `--skip-pypi-strategy`: Skips the strategy that collects dependencies from PyPI.
-- `--skip-gopkg-strategy`: Skips the strategy that collects dependencies from GoPkg.
+- `--deep-scanning`: Enables intensive source code analysis using [scancode-toolkit](https://scancode-toolkit.readthedocs.io/en/latest/getting-started/home.html). This will parse license and copyright information from full package source code. Note: This is a resource-intensive task that may take hours or days to process depending on package size.
+- `--no-pypi-strategy`: Skips the strategy that collects dependencies from PyPI.
+- `--no-gopkg-strategy`: Skips the strategy that collects dependencies from GoPkg.
+- `--no-github-sbom-strategy`: Skips the strategy that gets the dependency tree from GitHub.
 
 #### Cache Configuration
 

--- a/src/dd_license_attribution/cli/main_cli.py
+++ b/src/dd_license_attribution/cli/main_cli.py
@@ -228,6 +228,14 @@ def main(
             rich_help_panel="Scanning Options",
         ),
     ] = False,
+    skip_github_sbom: Annotated[
+        bool,
+        typer.Option(
+            "--no-github-sbom-strategy",
+            help="Skip the GitHub SBOM collection strategy.",
+            rich_help_panel="Scanning Options",
+        ),
+    ] = False,
     cache_dir: Annotated[
         str | None,
         typer.Option(
@@ -389,6 +397,9 @@ def main(
 
     if skip_gopkg:
         enabled_strategies["GoPkgsMetadataCollectionStrategy"] = False
+
+    if skip_github_sbom:
+        enabled_strategies["GitHubSbomMetadataCollectionStrategy"] = False
 
     if not github_token:
         github_client = GitHub()

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -4,9 +4,9 @@
 # Copyright 2024-present Datadog, Inc.
 
 import os
-import pytest
 from unittest.mock import Mock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from dd_license_attribution.cli.main_cli import app


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [X] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR adds a new CLI option (`no-github-sbom-strategy`) to optionally skip the GitHub SBOM strategy when collecting dependencies.

## How to reproduce and testing

I have added a unit test that tests the different `no-<strategy>-strategy` that was previously untested
