### PR TITLE
Removing deprecated config line with conflict in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "DataDog/ospo"
     labels:
       - "dependencies"
       - "python"
@@ -18,8 +16,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    reviewers:
-      - "DataDog/ospo"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
- **Removing conflicting reviewers line in Dependabot**

The change is a follow up to https://github.com/DataDog/dd-license-attribution/pull/83#issuecomment-2967180053 suggestion by dependabot about the deprecation announcement [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

Our CODEOWNERS is already up to date. 