### PR TITLE
[OSPO-132] Initial support for NodeJs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For more advanced usage, see the sections below.
 
 - python3.11+ - [Python install instructions](https://www.python.org/downloads/)
 - gopkg - [GoLang and GoPkg install instructions](https://go.dev/doc/install)
+- Node.js (v14 or newer) and npm (v6 or newer) - [Node.js install instructions](https://nodejs.org/en/download/)
 - libmagic (only on mac):
   - `brew install libmagic`
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 Datadog License Attribution Tracker is a tool that collects license and copyright information for third party dependencies of a project and returns a list of said dependencies and their licenses and copyright attributions, if found.
 
-As of today, Datadog License Attribution Tracker supports Go and Python projects. It will be extended in the future to support more languages.
+As of today, Datadog License Attribution Tracker supports Go, Python, and NodeJS projects. It will be extended in the future to support more languages.
 
-The tool collects license and other metadata information using multiple sources, including the GitHub API, pulled source code, the go-pkg list command output, and the metadata collected from successful dependency installation via PyPI.
+The tool collects license and other metadata information using multiple sources, including the GitHub API, pulled source code, the go-pkg list command output, and metadata collected from PyPI and NPM.
 It supports gathering data from various repositories to generate a comprehensive list of third party dependencies.
 
 Runs may take minutes or hours depending on the size of the project dependency tree and the depth of the scanning.
 
 ### Getting Started
 
-1. Install the required dependencies (see Requirements section below)
+1. Install the required dependencies (see the [Requirements](#requirements) section below)
 2. Clone this repository
 3. Install the package:
+
 ```bash
 pip install .
 ```
@@ -28,7 +29,7 @@ For more advanced usage, see the sections below.
 
 - python3.11+ - [Python install instructions](https://www.python.org/downloads/)
 - gopkg - [GoLang and GoPkg install instructions](https://go.dev/doc/install)
-- Node.js (v14 or newer) and npm (v6 or newer) - [Node.js install instructions](https://nodejs.org/en/download/)
+- Node.js (v14 or newer) and npm (v7 or newer) - [Node.js install instructions](https://nodejs.org/en/download/)
 - libmagic (only on mac):
   - `brew install libmagic`
 
@@ -58,6 +59,7 @@ The following optional parameters are available:
 - `--no-pypi-strategy`: Skips the strategy that collects dependencies from PyPI.
 - `--no-gopkg-strategy`: Skips the strategy that collects dependencies from GoPkg.
 - `--no-github-sbom-strategy`: Skips the strategy that gets the dependency tree from GitHub.
+- `--no-npm-strategy`: Skips the strategy that collects dependencies from NPM.
 
 #### Cache Configuration
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ For more advanced usage, see the sections below.
 ### Requirements
 
 - python3.11+ - [Python install instructions](https://www.python.org/downloads/)
-- gopkg - [GoLang and GoPkg install instructions](https://go.dev/doc/install)
-- Node.js (v14 or newer) and npm (v7 or newer) - [Node.js install instructions](https://nodejs.org/en/download/)
-- libmagic (only on mac):
+- libmagic (only on MacOS):
   - `brew install libmagic`
+
+#### Optional Requirements
+
+- gopkg - [GoLang and GoPkg install instructions](https://go.dev/doc/install). Not required when skipping the GoPkg strategy (--no-gopkg-strateg)
+- Node.js (v14 or newer) and npm (v7 or newer) - [Node.js install instructions](https://nodejs.org/en/download/). Not required when skipping the NPM strategy (--no-npm-strategy)
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For more advanced usage, see the sections below.
 
 #### Optional Requirements
 
-- gopkg - [GoLang and GoPkg install instructions](https://go.dev/doc/install). Not required when skipping the GoPkg strategy (--no-gopkg-strateg)
+- gopkg - [GoLang and GoPkg install instructions](https://go.dev/doc/install). Not required when skipping the GoPkg strategy (--no-gopkg-strategy)
 - Node.js (v14 or newer) and npm (v7 or newer) - [Node.js install instructions](https://nodejs.org/en/download/). Not required when skipping the NPM strategy (--no-npm-strategy)
 
 ### Usage

--- a/src/dd_license_attribution/adaptors/os.py
+++ b/src/dd_license_attribution/adaptors/os.py
@@ -44,3 +44,7 @@ def get_current_working_directory() -> str:
 def open_file(file_path: str) -> str:
     with open(file_path, "r") as file:
         return file.read()
+
+
+def path_join(path: str, *paths: str) -> str:
+    return os.path.join(path, *paths)

--- a/src/dd_license_attribution/cli/main_cli.py
+++ b/src/dd_license_attribution/cli/main_cli.py
@@ -55,6 +55,9 @@ from dd_license_attribution.metadata_collector.strategies.pypi_collection_strate
 from dd_license_attribution.metadata_collector.strategies.scan_code_toolkit_metadata_collection_strategy import (
     ScanCodeToolkitMetadataCollectionStrategy,
 )
+from dd_license_attribution.metadata_collector.strategies.npm_collection_strategy import (
+    NpmMetadataCollectionStrategy,
+)
 from dd_license_attribution.report_generator.report_generator import ReportGenerator
 from dd_license_attribution.report_generator.writters.csv_reporting_writter import (
     CSVReportingWritter,
@@ -236,6 +239,14 @@ def main(
             rich_help_panel="Scanning Options",
         ),
     ] = False,
+    skip_npm: Annotated[
+        bool,
+        typer.Option(
+            "--no-npm-strategy",
+            help="Skip the NPM collection strategy.",
+            rich_help_panel="Scanning Options",
+        ),
+    ] = False,
     cache_dir: Annotated[
         str | None,
         typer.Option(
@@ -338,6 +349,7 @@ def main(
         "GitHubSbomMetadataCollectionStrategy": True,
         "GoPkgsMetadataCollectionStrategy": True,
         "PythonPipMetadataCollectionStrategy": True,
+        "NpmMetadataCollectionStrategy": True,
         "ScanCodeToolkitMetadataCollectionStrategy": True,
         "GitHubRepositoryMetadataCollectionStrategy": True,
     }
@@ -401,6 +413,9 @@ def main(
     if skip_github_sbom:
         enabled_strategies["GitHubSbomMetadataCollectionStrategy"] = False
 
+    if skip_npm:
+        enabled_strategies["NpmMetadataCollectionStrategy"] = False
+
     if not github_token:
         github_client = GitHub()
     else:
@@ -430,6 +445,15 @@ def main(
         strategies.append(
             PypiMetadataCollectionStrategy(
                 package, source_code_manager, python_env_manager, project_scope
+            )
+        )
+
+    if enabled_strategies["NpmMetadataCollectionStrategy"]:
+        strategies.append(
+            NpmMetadataCollectionStrategy(
+                package,
+                source_code_manager,
+                project_scope,
             )
         )
 

--- a/src/dd_license_attribution/cli/main_cli.py
+++ b/src/dd_license_attribution/cli/main_cli.py
@@ -46,6 +46,9 @@ from dd_license_attribution.metadata_collector.strategies.github_sbom_collection
 from dd_license_attribution.metadata_collector.strategies.gopkg_collection_strategy import (
     GoPkgMetadataCollectionStrategy,
 )
+from dd_license_attribution.metadata_collector.strategies.npm_collection_strategy import (
+    NpmMetadataCollectionStrategy,
+)
 from dd_license_attribution.metadata_collector.strategies.override_strategy import (
     OverrideCollectionStrategy,
 )
@@ -54,9 +57,6 @@ from dd_license_attribution.metadata_collector.strategies.pypi_collection_strate
 )
 from dd_license_attribution.metadata_collector.strategies.scan_code_toolkit_metadata_collection_strategy import (
     ScanCodeToolkitMetadataCollectionStrategy,
-)
-from dd_license_attribution.metadata_collector.strategies.npm_collection_strategy import (
-    NpmMetadataCollectionStrategy,
 )
 from dd_license_attribution.report_generator.report_generator import ReportGenerator
 from dd_license_attribution.report_generator.writters.csv_reporting_writter import (

--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -7,10 +7,17 @@
 
 import json
 import logging
+from typing import Any, Dict, List
+
 import requests
-from typing import List, Dict, Any
 from giturlparse import validate as validate_git_url
 
+from dd_license_attribution.adaptors.os import (
+    open_file,
+    output_from_command,
+    path_exists,
+    path_join,
+)
 from dd_license_attribution.artifact_management.source_code_manager import (
     SourceCodeManager,
 )
@@ -20,12 +27,6 @@ from dd_license_attribution.metadata_collector.project_scope import (
 )
 from dd_license_attribution.metadata_collector.strategies.abstract_collection_strategy import (
     MetadataCollectionStrategy,
-)
-from dd_license_attribution.adaptors.os import (
-    path_exists,
-    path_join,
-    open_file,
-    output_from_command,
 )
 
 

--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -1,0 +1,203 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog \
+# (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+import json
+import logging
+import requests
+from typing import List
+from giturlparse import validate as validate_git_url
+
+from dd_license_attribution.artifact_management.source_code_manager import (
+    SourceCodeManager,
+)
+from dd_license_attribution.metadata_collector.metadata import Metadata
+from dd_license_attribution.metadata_collector.project_scope import (
+    ProjectScope,
+)
+from dd_license_attribution.metadata_collector.strategies.abstract_collection_strategy import (
+    MetadataCollectionStrategy,
+)
+from dd_license_attribution.adaptors.os import (
+    path_exists,
+    path_join,
+    open_file,
+    output_from_command,
+)
+
+
+class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
+    def __init__(
+        self,
+        top_package: str,
+        source_code_manager: SourceCodeManager,
+        project_scope: ProjectScope,
+    ) -> None:
+        self.top_package = top_package
+        self.source_code_manager = source_code_manager
+        self.only_root_project = project_scope == ProjectScope.ONLY_ROOT_PROJECT
+        self.only_transitive = (
+            project_scope == ProjectScope.ONLY_TRANSITIVE_DEPENDENCIES
+        )
+
+    def _extract_all_dependencies(self, lock_data: dict) -> dict[str, str]:
+        all_deps = {}
+
+        if "packages" not in lock_data:
+            logging.warning("No 'packages' key found in package-lock.json.")
+            return all_deps
+
+        packages = lock_data["packages"]
+        # Find the root package key
+        root_key = "" if "" in packages else "./" if "./" in packages else None
+        if root_key is None:
+            logging.warning("Root package not found in lockfile 'packages'.")
+            return all_deps
+
+        root_pkg = packages[root_key]
+        if "dependencies" in root_pkg:
+            all_deps.update(root_pkg["dependencies"])
+
+        self._extract_transitive_dependencies(packages, all_deps)
+        return all_deps
+
+    def _extract_transitive_dependencies(self, packages: dict, all_deps: dict) -> None:
+
+        processed_packages = set()
+
+        new_deps_found = True
+        while new_deps_found:
+            new_deps_found = False
+            current_deps = list(all_deps.items())
+
+            for pkg_name, _ in current_deps:
+                if pkg_name in processed_packages:
+                    continue
+
+                node_modules_key = f"node_modules/{pkg_name}"
+                if node_modules_key in packages:
+                    pkg_data = packages[node_modules_key]
+                    if "dependencies" in pkg_data:
+                        for dep_name, dep_version in pkg_data["dependencies"].items():
+                            if dep_name not in all_deps:
+                                all_deps[dep_name] = dep_version
+                                new_deps_found = True
+
+                processed_packages.add(pkg_name)
+
+    def augment_metadata(self, metadata: List[Metadata]) -> List[Metadata]:
+        updated_metadata = metadata.copy()
+        source_code_ref = self.source_code_manager.get_code(self.top_package)
+        if not source_code_ref:
+            return updated_metadata
+        project_path = source_code_ref.local_full_path
+        # Run npm install --package-lock-only to generate package-lock.json
+        try:
+            output_from_command(
+                f"CWD=`pwd`; cd {project_path} && "
+                "npm install --package-lock-only --force; cd $CWD"
+            )
+        except Exception as e:
+            logging.warning(f"Failed to run npm install for {self.top_package}: {e}")
+            return updated_metadata
+        lock_path = path_join(project_path, "package-lock.json")
+        if not path_exists(lock_path):
+            logging.warning(f"No package-lock.json found in {project_path}")
+            return updated_metadata
+        try:
+            lock_data = open_file(lock_path)
+        except Exception as e:
+            logging.warning(f"Failed to read package-lock.json: {e}")
+            return updated_metadata
+
+        all_deps = self._extract_all_dependencies(lock_data)
+
+        if self.only_root_project:
+            return updated_metadata
+        if self.only_transitive:
+            updated_metadata = [
+                m for m in updated_metadata if m.name != self.top_package
+            ]
+        for dep_name, version in all_deps.items():
+            # Remove ^, ~, >, or >= from version if present
+            if isinstance(version, str) and version:
+                if version.startswith(">="):
+                    version = version[2:]
+                elif version[0] in {"^", "~", ">"}:
+                    version = version[1:]
+            # Fetch metadata from npmjs registry API
+            license = []
+            copyright = []
+            repository_url = None
+            homepage_url = None
+            try:
+                resp = requests.get(
+                    f"https://registry.npmjs.org/{dep_name}/{version}", timeout=5
+                )
+                if resp.status_code == 200:
+                    pkg_data = resp.json()
+                    if "license" in pkg_data and pkg_data["license"]:
+                        license = [str(pkg_data["license"])]
+                    if "author" in pkg_data and pkg_data["author"]:
+                        if (
+                            isinstance(pkg_data["author"], dict)
+                            and "name" in pkg_data["author"]
+                        ):
+                            copyright = [str(pkg_data["author"]["name"])]
+                        elif isinstance(pkg_data["author"], str):
+                            copyright = [pkg_data["author"]]
+                    if "repository" in pkg_data and pkg_data["repository"]:
+                        repo = pkg_data["repository"]
+                        if isinstance(repo, dict) and "url" in repo:
+                            repository_url = repo["url"]
+                        elif isinstance(repo, str):
+                            repository_url = repo
+                    if (
+                        not repository_url
+                        and "homepage" in pkg_data
+                        and pkg_data["homepage"]
+                    ):
+                        homepage_url = pkg_data["homepage"]
+            except Exception as e:
+                logging.warning(
+                    f"Failed to fetch npm registry metadata for "
+                    f"{dep_name}@{version}: {e}"
+                )
+            # Set origin: prefer repository, then homepage, then npm:{name}
+            if repository_url:
+                origin = repository_url
+            elif homepage_url:
+                origin = homepage_url
+            else:
+                origin = f"npm:{dep_name}"
+            found = False
+            for meta in updated_metadata:
+                if meta.name == dep_name:
+                    found = True
+                    # Update origin if not a valid git url or missing
+                    if (
+                        not meta.origin or not validate_git_url(meta.origin)
+                    ) and origin:
+                        meta.origin = origin
+                    if not meta.license and license:
+                        meta.license = license
+                    if not meta.copyright and copyright:
+                        meta.copyright = copyright
+                    if not meta.version and version:
+                        meta.version = version
+                    break
+            if not found:
+                updated_metadata.append(
+                    Metadata(
+                        name=dep_name,
+                        version=version,
+                        origin=origin,
+                        local_src_path=None,
+                        license=license,
+                        copyright=copyright,
+                    )
+                )
+        return updated_metadata

--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -8,7 +8,7 @@
 import json
 import logging
 import requests
-from typing import List
+from typing import List, Dict, Any
 from giturlparse import validate as validate_git_url
 
 from dd_license_attribution.artifact_management.source_code_manager import (
@@ -43,8 +43,8 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
             project_scope == ProjectScope.ONLY_TRANSITIVE_DEPENDENCIES
         )
 
-    def _extract_all_dependencies(self, lock_data: dict) -> dict[str, str]:
-        all_deps = {}
+    def _extract_all_dependencies(self, lock_data: Dict[str, Any]) -> Dict[str, str]:
+        all_deps: Dict[str, str] = {}
 
         if "packages" not in lock_data:
             logging.warning("No 'packages' key found in package-lock.json.")
@@ -64,7 +64,9 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
         self._extract_transitive_dependencies(packages, all_deps)
         return all_deps
 
-    def _extract_transitive_dependencies(self, packages: dict, all_deps: dict) -> None:
+    def _extract_transitive_dependencies(
+        self, packages: Dict[str, Any], all_deps: Dict[str, str]
+    ) -> None:
 
         processed_packages = set()
 
@@ -104,11 +106,12 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
             logging.warning(f"Failed to run npm install for {self.top_package}: {e}")
             return updated_metadata
         lock_path = path_join(project_path, "package-lock.json")
+        lock_data = {}
         if not path_exists(lock_path):
             logging.warning(f"No package-lock.json found in {project_path}")
             return updated_metadata
         try:
-            lock_data = open_file(lock_path)
+            lock_data = json.loads(open_file(lock_path))
         except Exception as e:
             logging.warning(f"Failed to read package-lock.json: {e}")
             return updated_metadata

--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -55,7 +55,9 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
         # Find the root package key
         root_key = "" if "" in packages else "./" if "./" in packages else None
         if root_key is None:
-            logging.warning("Root package not found in lockfile 'packages'.")
+            logging.warning(
+                "A root package wasn't found. Collecting NodeJS dependencies from none NodeJS projects is not supported yet."
+            )
             return all_deps
 
         root_pkg = packages[root_key]

--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -167,6 +167,11 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
                         and pkg_data["homepage"]
                     ):
                         homepage_url = pkg_data["homepage"]
+                else:
+                    logging.warning(
+                        f"Failed to fetch npm registry metadata for "
+                        f"{dep_name}@{version}: {resp.status_code}, {resp.text}"
+                    )
             except Exception as e:
                 logging.warning(
                     f"Failed to fetch npm registry metadata for "

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -148,7 +148,9 @@ def test_npm_collection_strategy_is_bypassed_if_only_root_project(
     ]
     result = strategy.augment_metadata(initial_metadata)
     assert result == initial_metadata
-    mock_output_from_command.assert_called_once()
+    mock_output_from_command.assert_called_once_with(
+        f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
+    )
     mock_exists.assert_called_once()
     mock_path_join.assert_called_once()
     mock_open.assert_called_once()
@@ -223,7 +225,9 @@ def test_npm_collection_strategy_adds_npm_metadata(
         ),
     ]
     assert result == expected_metadata
-    mock_output_from_command.assert_called_once()
+    mock_output_from_command.assert_called_once_with(
+        f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
+    )
     mock_exists.assert_called_once()
     mock_path_join.assert_called_once()
     mock_open.assert_called_once()
@@ -330,7 +334,9 @@ def test_npm_collection_strategy_extracts_transitive_dependencies(
         ),
     ]
     assert result == expected_metadata
-    mock_output_from_command.assert_called_once()
+    mock_output_from_command.assert_called_once_with(
+        f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
+    )
     mock_exists.assert_called_once()
     mock_path_join.assert_called_once()
     mock_open.assert_called_once()
@@ -393,7 +399,9 @@ def test_npm_collection_strategy_avoids_duplicates_and_respects_only_transitive(
         ),
     ]
     assert result == expected_metadata
-    mock_output_from_command.assert_called_once()
+    mock_output_from_command.assert_called_once_with(
+        f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
+    )
     mock_exists.assert_called_once()
     mock_path_join.assert_called_once()
     mock_open.assert_called_once()
@@ -435,7 +443,9 @@ def test_npm_collection_strategy_handles_missing_packages_key(
     ]
     result = strategy.augment_metadata(initial_metadata)
     # Should return original metadata when packages key is missing
-    mock_output_from_command.assert_called_once()
+    mock_output_from_command.assert_called_once_with(
+        f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
+    )
     mock_exists.assert_called_once()
     mock_path_join.assert_called_once()
     mock_open.assert_called_once()
@@ -477,7 +487,9 @@ def test_npm_collection_strategy_handles_missing_root_package(
     result = strategy.augment_metadata(initial_metadata)
     # Should return original metadata when root package is missing
     assert result == initial_metadata
-    mock_output_from_command.assert_called_once()
+    mock_output_from_command.assert_called_once_with(
+        f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
+    )
     mock_exists.assert_called_once()
     mock_path_join.assert_called_once()
     mock_open.assert_called_once()
@@ -535,7 +547,9 @@ def test_npm_collection_strategy_handles_registry_api_failures(
     assert dep2_meta is not None
     assert dep1_meta.license == []  # Should be empty due to 404
     assert dep2_meta.license == ["Apache-2.0"]  # Should have license
-    mock_output_from_command.assert_called_once()
+    mock_output_from_command.assert_called_once_with(
+        f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
+    )
     mock_exists.assert_called_once()
     mock_path_join.assert_called_once()
     mock_open.assert_called_once()
@@ -592,7 +606,9 @@ def test_npm_collection_strategy_logs_warning_on_non_200_response(
     assert dep_meta.version == "1.0.0"
     assert dep_meta.license == []
     assert dep_meta.copyright == []
-    mock_output_from_command.assert_called_once()
+    mock_output_from_command.assert_called_once_with(
+        f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
+    )
     mock_exists.assert_called_once()
     mock_path_join.assert_called_once()
     mock_open.assert_called_once()
@@ -633,4 +649,6 @@ def test_npm_collection_strategy_handles_npm_install_failure(
     assert any(expected_warning in record.message for record in caplog.records)
 
     assert result == initial_metadata
-    mock_output_from_command.assert_called_once()
+    mock_output_from_command.assert_called_once_with(
+        "CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
+    )

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -5,7 +5,7 @@
 
 import pytest_mock
 from unittest import mock
-from typing import Any, Dict, List
+from typing import Any
 from dd_license_attribution.artifact_management.artifact_manager import (
     SourceCodeReference,
 )
@@ -14,6 +14,7 @@ from dd_license_attribution.metadata_collector.project_scope import ProjectScope
 from dd_license_attribution.metadata_collector.strategies.npm_collection_strategy import (
     NpmMetadataCollectionStrategy,
 )
+import json
 
 
 def create_source_code_manager_mock() -> mock.Mock:
@@ -30,8 +31,8 @@ def create_source_code_manager_mock() -> mock.Mock:
 
 def setup_npm_strategy_mocks(
     mocker: pytest_mock.MockFixture,
-    package_lock: Dict[str, Any],
-    requests_responses: List[mock.Mock],
+    package_lock: dict[str, Any],
+    requests_responses: list[mock.Mock],
 ) -> None:
     """Setup common mocks for npm collection strategy tests."""
 
@@ -42,10 +43,10 @@ def setup_npm_strategy_mocks(
 
     def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
         if "package-lock.json" in path:
-            return package_lock
+            return json.dumps(package_lock)
         raise FileNotFoundError
 
-    def fake_path_join(*args):
+    def fake_path_join(*args: Any) -> str:
         result = "/".join(args)
         return result
 
@@ -106,12 +107,12 @@ def test_npm_collection_strategy_is_bypassed_if_only_root_project(
     mocker: pytest_mock.MockFixture,
 ) -> None:
     source_code_manager_mock = create_source_code_manager_mock()
-    package_lock = {
+    package_lock: dict[str, Any] = {
         "packages": {
             "": {"dependencies": {}},
         }
     }
-    requests_responses = []
+    requests_responses: list[mock.Mock] = []
     setup_npm_strategy_mocks(mocker, package_lock, requests_responses)
     strategy = NpmMetadataCollectionStrategy(
         "package1", source_code_manager_mock, ProjectScope.ONLY_ROOT_PROJECT
@@ -134,7 +135,7 @@ def test_npm_collection_strategy_adds_npm_metadata(
     mocker: pytest_mock.MockFixture,
 ) -> None:
     source_code_manager_mock = create_source_code_manager_mock()
-    package_lock = {
+    package_lock: dict[str, Any] = {
         "packages": {
             "": {"dependencies": {"dep1": "1.0.0", "dep2": "2.0.0"}},
             "node_modules/dep1": {"version": "1.0.0", "dependencies": {}},
@@ -142,7 +143,7 @@ def test_npm_collection_strategy_adds_npm_metadata(
         }
     }
 
-    requests_responses = [
+    requests_responses: list[mock.Mock] = [
         mock.Mock(status_code=200, json=lambda: {"license": "MIT", "author": "Alice"}),
         mock.Mock(
             status_code=200, json=lambda: {"license": "Apache-2.0", "author": "Bob"}
@@ -198,7 +199,7 @@ def test_npm_collection_strategy_extracts_transitive_dependencies(
     mocker: pytest_mock.MockFixture,
 ) -> None:
     source_code_manager_mock = create_source_code_manager_mock()
-    package_lock = {
+    package_lock: dict[str, Any] = {
         "packages": {
             "": {"dependencies": {"dep1": "1.0.0"}},
             "node_modules/dep1": {
@@ -214,7 +215,7 @@ def test_npm_collection_strategy_extracts_transitive_dependencies(
         }
     }
 
-    requests_responses = [
+    requests_responses: list[mock.Mock] = [
         mock.Mock(status_code=200, json=lambda: {"license": "MIT", "author": "Alice"}),
         mock.Mock(
             status_code=200, json=lambda: {"license": "Apache-2.0", "author": "Bob"}
@@ -346,13 +347,13 @@ def test_npm_collection_strategy_handles_missing_packages_key(
     mocker: pytest_mock.MockFixture,
 ) -> None:
     source_code_manager_mock = create_source_code_manager_mock()
-    package_lock = {
+    package_lock: dict[str, Any] = {
         "dependencies": {
             "dep1": {"version": "1.0.0", "resolved": "https://npmjs.com/dep1"},
         }
     }
 
-    requests_responses = []
+    requests_responses: list[mock.Mock] = []
 
     setup_npm_strategy_mocks(mocker, package_lock, requests_responses)
 
@@ -378,11 +379,11 @@ def test_npm_collection_strategy_handles_missing_root_package(
     mocker: pytest_mock.MockFixture,
 ) -> None:
     source_code_manager_mock = create_source_code_manager_mock()
-    package_lock = {
+    package_lock: dict[str, Any] = {
         "packages": {"node_modules/dep1": {"version": "1.0.0", "dependencies": {}}}
     }
 
-    requests_responses = []
+    requests_responses: list[mock.Mock] = []
 
     setup_npm_strategy_mocks(mocker, package_lock, requests_responses)
 

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -3,9 +3,12 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2025-present Datadog, Inc.
 
-import pytest_mock
-from unittest import mock
+import json
 from typing import Any
+from unittest import mock
+
+import pytest_mock
+
 from dd_license_attribution.artifact_management.artifact_manager import (
     SourceCodeReference,
 )
@@ -14,7 +17,6 @@ from dd_license_attribution.metadata_collector.project_scope import ProjectScope
 from dd_license_attribution.metadata_collector.strategies.npm_collection_strategy import (
     NpmMetadataCollectionStrategy,
 )
-import json
 
 
 def create_source_code_manager_mock() -> mock.Mock:

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -1,0 +1,658 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+import json
+import pytest_mock
+from unittest import mock
+from typing import Any
+from dd_license_attribution.artifact_management.artifact_manager import (
+    SourceCodeReference,
+)
+from dd_license_attribution.metadata_collector.metadata import Metadata
+from dd_license_attribution.metadata_collector.project_scope import ProjectScope
+from dd_license_attribution.metadata_collector.strategies.npm_collection_strategy import (
+    NpmMetadataCollectionStrategy,
+)
+
+
+def test_npm_collection_strategy_no_package_lock(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    source_code_manager_mock = mocker.Mock()
+    source_code_manager_mock.get_code.return_value = SourceCodeReference(
+        repo_url="https://github.com/org/package1",
+        branch="main",
+        local_root_path="cache_dir/org_package1",
+        local_full_path="cache_dir/org_package1",
+    )
+    mocker.patch("dd_license_attribution.adaptors.os.path_exists", return_value=False)
+    mocker.patch("dd_license_attribution.adaptors.os.output_from_command")
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+    initial_metadata = [
+        Metadata(
+            name="package1",
+            origin=None,
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+    result = strategy.augment_metadata(initial_metadata)
+    assert result == initial_metadata
+
+
+def test_npm_collection_strategy_is_bypassed_if_only_root_project(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    source_code_manager_mock = mocker.Mock()
+    source_code_manager_mock.get_code.return_value = SourceCodeReference(
+        repo_url="https://github.com/org/package1",
+        branch="main",
+        local_root_path="cache_dir/org_package1",
+        local_full_path="cache_dir/org_package1",
+    )
+    mocker.patch("dd_license_attribution.adaptors.os.path_exists", return_value=True)
+    mocker.patch("dd_license_attribution.adaptors.os.output_from_command")
+    mocker.patch(
+        "dd_license_attribution.adaptors.os.open_file",
+        mock.mock_open(read_data=json.dumps({"packages": {"": {"dependencies": {}}}})),
+    )
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ONLY_ROOT_PROJECT
+    )
+    initial_metadata = [
+        Metadata(
+            name="package1",
+            origin=None,
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+    result = strategy.augment_metadata(initial_metadata)
+    assert result == initial_metadata
+
+
+def test_npm_collection_strategy_adds_npm_metadata(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    source_code_manager_mock = mocker.Mock()
+    source_code_manager_mock.get_code.return_value = SourceCodeReference(
+        repo_url="https://github.com/org/package1",
+        branch="main",
+        local_root_path="cache_dir/org_package1",
+        local_full_path="cache_dir/org_package1",
+    )
+    package_lock = {
+        "packages": {
+            "": {"dependencies": {"dep1": "1.0.0", "dep2": "2.0.0"}},
+            "node_modules/dep1": {"version": "1.0.0", "dependencies": {}},
+            "node_modules/dep2": {"version": "2.0.0", "dependencies": {}},
+        }
+    }
+
+    def fake_exists(path: str) -> bool:
+        if path.endswith("package-lock.json"):
+            return True
+        return False
+
+    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
+        if "package-lock.json" in path:
+            return package_lock
+        raise FileNotFoundError
+
+    def fake_path_join(*args):
+        result = "/".join(args)
+        return result
+
+    def fake_output_from_command(command: str) -> str:
+        return "npm install completed successfully"
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_exists",
+        side_effect=fake_exists,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_join",
+        side_effect=fake_path_join,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        side_effect=fake_output_from_command,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.open_file",
+        side_effect=fake_open,
+    )
+    mocker.patch(
+        "requests.get",
+        side_effect=[
+            mock.Mock(
+                status_code=200, json=lambda: {"license": "MIT", "author": "Alice"}
+            ),
+            mock.Mock(
+                status_code=200, json=lambda: {"license": "Apache-2.0", "author": "Bob"}
+            ),
+        ],
+    )
+
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+    initial_metadata = [
+        Metadata(
+            name="package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+    result = strategy.augment_metadata(initial_metadata)
+    expected_metadata = [
+        Metadata(
+            name="package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+        Metadata(
+            name="dep1",
+            version="1.0.0",
+            origin="npm:dep1",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["Alice"],
+        ),
+        Metadata(
+            name="dep2",
+            version="2.0.0",
+            origin="npm:dep2",
+            local_src_path=None,
+            license=["Apache-2.0"],
+            copyright=["Bob"],
+        ),
+    ]
+    assert result == expected_metadata
+
+
+def test_npm_collection_strategy_extracts_transitive_dependencies(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    source_code_manager_mock = mocker.Mock()
+    source_code_manager_mock.get_code.return_value = SourceCodeReference(
+        repo_url="https://github.com/org/package1",
+        branch="main",
+        local_root_path="cache_dir/org_package1",
+        local_full_path="cache_dir/org_package1",
+    )
+    package_lock = {
+        "packages": {
+            "": {"dependencies": {"dep1": "1.0.0"}},
+            "node_modules/dep1": {
+                "version": "1.0.0",
+                "dependencies": {"transitive1": "1.1.0", "transitive2": "1.2.0"},
+            },
+            "node_modules/transitive1": {
+                "version": "1.1.0",
+                "dependencies": {"deep1": "2.0.0"},
+            },
+            "node_modules/transitive2": {"version": "1.2.0", "dependencies": {}},
+            "node_modules/deep1": {"version": "2.0.0", "dependencies": {}},
+        }
+    }
+
+    def fake_exists(path: str) -> bool:
+        if "package-lock.json" in path:
+            return True
+        return False
+
+    def fake_path_join(*args):
+        result = "/".join(args)
+        return result
+
+    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
+        if "package-lock.json" in path:
+            return package_lock
+        raise FileNotFoundError
+
+    def fake_output_from_command(command: str) -> str:
+        return "npm install completed successfully"
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_exists",
+        side_effect=fake_exists,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_join",
+        side_effect=fake_path_join,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.open_file",
+        side_effect=fake_open,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        side_effect=fake_output_from_command,
+    )
+    mocker.patch(
+        "requests.get",
+        side_effect=[
+            mock.Mock(
+                status_code=200, json=lambda: {"license": "MIT", "author": "Alice"}
+            ),
+            mock.Mock(
+                status_code=200, json=lambda: {"license": "Apache-2.0", "author": "Bob"}
+            ),
+            mock.Mock(
+                status_code=200,
+                json=lambda: {"license": "BSD-3-Clause", "author": "Charlie"},
+            ),
+            mock.Mock(
+                status_code=200, json=lambda: {"license": "GPL-3.0", "author": "David"}
+            ),
+        ],
+    )
+
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+    initial_metadata = [
+        Metadata(
+            name="package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+    result = strategy.augment_metadata(initial_metadata)
+
+    expected_metadata = [
+        Metadata(
+            name="package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+        Metadata(
+            name="dep1",
+            version="1.0.0",
+            origin="npm:dep1",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["Alice"],
+        ),
+        Metadata(
+            name="transitive1",
+            version="1.1.0",
+            origin="npm:transitive1",
+            local_src_path=None,
+            license=["Apache-2.0"],
+            copyright=["Bob"],
+        ),
+        Metadata(
+            name="transitive2",
+            version="1.2.0",
+            origin="npm:transitive2",
+            local_src_path=None,
+            license=["BSD-3-Clause"],
+            copyright=["Charlie"],
+        ),
+        Metadata(
+            name="deep1",
+            version="2.0.0",
+            origin="npm:deep1",
+            local_src_path=None,
+            license=["GPL-3.0"],
+            copyright=["David"],
+        ),
+    ]
+    assert result == expected_metadata
+
+
+def test_npm_collection_strategy_avoids_duplicates_and_respects_only_transitive(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    source_code_manager_mock = mocker.Mock()
+    source_code_manager_mock.get_code.return_value = SourceCodeReference(
+        repo_url="https://github.com/org/package1",
+        branch="main",
+        local_root_path="cache_dir/org_package1",
+        local_full_path="cache_dir/org_package1",
+    )
+    package_lock = {
+        "packages": {
+            "": {"dependencies": {"dep1": "1.0.0"}},
+            "node_modules/dep1": {"version": "1.0.0", "dependencies": {}},
+        }
+    }
+
+    def fake_exists(path: str) -> bool:
+        if "package-lock.json" in path:
+            return True
+        return False
+
+    def fake_path_join(*args):
+        result = "/".join(args)
+        return result
+
+    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
+        if "package-lock.json" in path:
+            return package_lock
+        raise FileNotFoundError
+
+    def fake_output_from_command(command: str) -> str:
+        return "npm install completed successfully"
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_exists",
+        side_effect=fake_exists,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_join",
+        side_effect=fake_path_join,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.open_file",
+        side_effect=fake_open,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        side_effect=fake_output_from_command,
+    )
+    mocker.patch(
+        "requests.get",
+        side_effect=[
+            mock.Mock(
+                status_code=200, json=lambda: {"license": "MIT", "author": "Alice"}
+            )
+        ],
+    )
+
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ONLY_TRANSITIVE_DEPENDENCIES
+    )
+    initial_metadata = [
+        Metadata(
+            name="package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+    result = strategy.augment_metadata(initial_metadata)
+    expected_metadata = [
+        Metadata(
+            name="dep1",
+            version="1.0.0",
+            origin="npm:dep1",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["Alice"],
+        ),
+    ]
+    assert result == expected_metadata
+
+
+def test_npm_collection_strategy_handles_missing_packages_key(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    source_code_manager_mock = mocker.Mock()
+    source_code_manager_mock.get_code.return_value = SourceCodeReference(
+        repo_url="https://github.com/org/package1",
+        branch="main",
+        local_root_path="cache_dir/org_package1",
+        local_full_path="cache_dir/org_package1",
+    )
+    package_lock = {
+        "dependencies": {
+            "dep1": {"version": "1.0.0", "resolved": "https://npmjs.com/dep1"},
+        }
+    }
+
+    def fake_exists(path: str) -> bool:
+        if "package-lock.json" in path:
+            return True
+        return False
+
+    def fake_path_join(*args):
+        result = "/".join(args)
+        return result
+
+    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
+        if "package-lock.json" in path:
+            return package_lock
+        raise FileNotFoundError
+
+    def fake_output_from_command(command: str) -> str:
+        return "npm install completed successfully"
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_exists",
+        side_effect=fake_exists,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_join",
+        side_effect=fake_path_join,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.open_file",
+        side_effect=fake_open,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        side_effect=fake_output_from_command,
+    )
+
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+    initial_metadata = [
+        Metadata(
+            name="package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+    result = strategy.augment_metadata(initial_metadata)
+    # Should return original metadata when packages key is missing
+    assert result == initial_metadata
+
+
+def test_npm_collection_strategy_handles_missing_root_package(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    source_code_manager_mock = mocker.Mock()
+    source_code_manager_mock.get_code.return_value = SourceCodeReference(
+        repo_url="https://github.com/org/package1",
+        branch="main",
+        local_root_path="cache_dir/org_package1",
+        local_full_path="cache_dir/org_package1",
+    )
+    package_lock = {
+        "packages": {"node_modules/dep1": {"version": "1.0.0", "dependencies": {}}}
+    }
+
+    def fake_exists(path: str) -> bool:
+        if "package-lock.json" in path:
+            return True
+        return False
+
+    def fake_path_join(*args):
+        result = "/".join(args)
+        return result
+
+    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
+        if "package-lock.json" in path:
+            return package_lock
+        raise FileNotFoundError
+
+    def fake_output_from_command(command: str) -> str:
+        return "npm install completed successfully"
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_exists",
+        side_effect=fake_exists,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_join",
+        side_effect=fake_path_join,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.open_file",
+        side_effect=fake_open,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        side_effect=fake_output_from_command,
+    )
+
+    mocker.patch("dd_license_attribution.adaptors.os.output_from_command")
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+    initial_metadata = [
+        Metadata(
+            name="package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+    result = strategy.augment_metadata(initial_metadata)
+    # Should return original metadata when root package is missing
+    assert result == initial_metadata
+
+
+def test_npm_collection_strategy_handles_registry_api_failures(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    source_code_manager_mock = mocker.Mock()
+    source_code_manager_mock.get_code.return_value = SourceCodeReference(
+        repo_url="https://github.com/org/package1",
+        branch="main",
+        local_root_path="cache_dir/org_package1",
+        local_full_path="cache_dir/org_package1",
+    )
+    package_lock = {
+        "packages": {
+            "": {"dependencies": {"dep1": "1.0.0", "dep2": "2.0.0"}},
+            "node_modules/dep1": {"version": "1.0.0", "dependencies": {}},
+            "node_modules/dep2": {"version": "2.0.0", "dependencies": {}},
+        }
+    }
+
+    def fake_exists(path: str) -> bool:
+        if "package-lock.json" in path:
+            return True
+        return False
+
+    def fake_path_join(*args):
+        result = "/".join(args)
+        return result
+
+    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
+        if "package-lock.json" in path:
+            return package_lock
+        raise FileNotFoundError
+
+    def fake_output_from_command(command: str) -> str:
+        return "npm install completed successfully"
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_exists",
+        side_effect=fake_exists,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_join",
+        side_effect=fake_path_join,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.open_file",
+        side_effect=fake_open,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        side_effect=fake_output_from_command,
+    )
+
+    mocker.patch(
+        "requests.get",
+        side_effect=[
+            mock.Mock(status_code=404),  # dep1 not found
+            mock.Mock(
+                status_code=200, json=lambda: {"license": "Apache-2.0", "author": "Bob"}
+            ),
+        ],
+    )
+
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+    initial_metadata = [
+        Metadata(
+            name="package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+    result = strategy.augment_metadata(initial_metadata)
+
+    # Should have both dependencies, but dep1 with empty license/copyright
+    assert len(result) == 3  # package1 + dep1 + dep2
+
+    # Find dep1 and dep2 in results
+    dep1_meta = next((m for m in result if m.name == "dep1"), None)
+    dep2_meta = next((m for m in result if m.name == "dep2"), None)
+
+    assert dep1_meta is not None
+    assert dep2_meta is not None
+    assert dep1_meta.license == []  # Should be empty due to 404
+    assert dep2_meta.license == ["Apache-2.0"]  # Should have license


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [X] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [X] Documentation Update

## Description

Added a NPM strategy for NodeJS projects. 

The strategy currently only collects non dev dependencies and can be skipped with the `--no-npm-strategy` option.

A potential follow up for this would be to add an option (maybe a global option that works in most strategies) to select whether to optionally also collect dev dependencies.

## How to reproduce and testing

The feature includes complete unit tests.

To manually test the feature, the recommendation is to test it against a NodeJS project, skipping the Github SBOM strategy (that is a bit greedy and would include `dev` related dependencies).

For example:

```
dd-license-attribution https://github.com/DataDog/dd-trace-js  --no-github-sbom-strategy 
```
