### PR TITLE
Add an option to skip the scantoolkit strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following optional parameters are available:
 - `--no-gopkg-strategy`: Skips the strategy that collects dependencies from GoPkg.
 - `--no-github-sbom-strategy`: Skips the strategy that gets the dependency tree from GitHub.
 - `--no-npm-strategy`: Skips the strategy that collects dependencies from NPM.
-- `--no-scantoolkit-strategy`: Skips the strategy that gets licenses and copyright attribution using ScanCode-Toolkit.
+- `--no-scancode-strategy`: Skips the strategy that gets licenses and copyright attribution using ScanCode Toolkit.
 
 #### Cache Configuration
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following optional parameters are available:
 - `--no-gopkg-strategy`: Skips the strategy that collects dependencies from GoPkg.
 - `--no-github-sbom-strategy`: Skips the strategy that gets the dependency tree from GitHub.
 - `--no-npm-strategy`: Skips the strategy that collects dependencies from NPM.
+- `--no-scantoolkit-strategy`: Skips the strategy that gets licenses and copyright attribution using ScanCode-Toolkit.
 
 #### Cache Configuration
 

--- a/src/dd_license_attribution/cli/main_cli.py
+++ b/src/dd_license_attribution/cli/main_cli.py
@@ -247,6 +247,14 @@ def main(
             rich_help_panel="Scanning Options",
         ),
     ] = False,
+    skip_scantoolkit: Annotated[
+        bool,
+        typer.Option(
+            "--no-scantoolkit-strategy",
+            help="Skip the ScanCodeToolkit collection strategy.",
+            rich_help_panel="Scanning Options",
+        ),
+    ] = False,
     cache_dir: Annotated[
         str | None,
         typer.Option(
@@ -415,6 +423,9 @@ def main(
 
     if skip_npm:
         enabled_strategies["NpmMetadataCollectionStrategy"] = False
+
+    if skip_scantoolkit:
+        enabled_strategies["ScanCodeToolkitMetadataCollectionStrategy"] = False
 
     if not github_token:
         github_client = GitHub()

--- a/src/dd_license_attribution/cli/main_cli.py
+++ b/src/dd_license_attribution/cli/main_cli.py
@@ -247,10 +247,10 @@ def main(
             rich_help_panel="Scanning Options",
         ),
     ] = False,
-    skip_scantoolkit: Annotated[
+    skip_scancode: Annotated[
         bool,
         typer.Option(
-            "--no-scantoolkit-strategy",
+            "--no-scancode-strategy",
             help="Skip the ScanCodeToolkit collection strategy.",
             rich_help_panel="Scanning Options",
         ),
@@ -424,7 +424,7 @@ def main(
     if skip_npm:
         enabled_strategies["NpmMetadataCollectionStrategy"] = False
 
-    if skip_scantoolkit:
+    if skip_scancode:
         enabled_strategies["ScanCodeToolkitMetadataCollectionStrategy"] = False
 
     if not github_token:

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -51,6 +51,7 @@ def test_github_auth_env() -> None:
         (["--no-pypi-strategy"], "PythonPipMetadataCollectionStrategy"),
         (["--no-gopkg-strategy"], "GoPkgsMetadataCollectionStrategy"),
         (["--no-github-sbom-strategy"], "GitHubSbomMetadataCollectionStrategy"),
+        (["--no-scantoolkit-strategy"], "ScanCodeToolkitMetadataCollectionStrategy"),
     ],
 )
 @patch("dd_license_attribution.cli.main_cli.GitHub")
@@ -100,6 +101,7 @@ def test_skip_all_strategies(
             "--no-pypi-strategy",
             "--no-gopkg-strategy",
             "--no-github-sbom-strategy",
+            "--no-scantoolkit-strategy",
         ],
     )
     assert result.exit_code == 0
@@ -110,6 +112,7 @@ def test_skip_all_strategies(
     assert "PythonPipMetadataCollectionStrategy" not in strategy_classes
     assert "GoPkgsMetadataCollectionStrategy" not in strategy_classes
     assert "GitHubSbomMetadataCollectionStrategy" not in strategy_classes
+    assert "ScanCodeToolkitMetadataCollectionStrategy" not in strategy_classes
 
 
 def test_missing_package() -> None:

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -51,7 +51,7 @@ def test_github_auth_env() -> None:
         (["--no-pypi-strategy"], "PythonPipMetadataCollectionStrategy"),
         (["--no-gopkg-strategy"], "GoPkgsMetadataCollectionStrategy"),
         (["--no-github-sbom-strategy"], "GitHubSbomMetadataCollectionStrategy"),
-        (["--no-scantoolkit-strategy"], "ScanCodeToolkitMetadataCollectionStrategy"),
+        (["--no-scancode-strategy"], "ScanCodeToolkitMetadataCollectionStrategy"),
     ],
 )
 @patch("dd_license_attribution.cli.main_cli.GitHub")
@@ -101,7 +101,7 @@ def test_skip_all_strategies(
             "--no-pypi-strategy",
             "--no-gopkg-strategy",
             "--no-github-sbom-strategy",
-            "--no-scantoolkit-strategy",
+            "--no-scancode-strategy",
         ],
     )
     assert result.exit_code == 0


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [X] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR adds a new option to the CLI to skip the ScanToolkit strategy

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
