### PR TITLE
Bugfix bad remapping of branch in mirror

### DIFF
--- a/src/dd_license_attribution/config/__init__.py
+++ b/src/dd_license_attribution/config/__init__.py
@@ -2,3 +2,8 @@
 #
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2024-present Datadog, Inc.
+
+from .cli_configs import Config, default_config
+from .json_config_parser import JsonConfigParser
+
+__all__ = ["Config", "default_config", "JsonConfigParser"]

--- a/src/dd_license_attribution/config/json_config_parser.py
+++ b/src/dd_license_attribution/config/json_config_parser.py
@@ -1,0 +1,149 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2024-present Datadog, Inc.
+
+import json
+import logging
+from typing import Optional
+
+from dd_license_attribution.adaptors.os import open_file
+from dd_license_attribution.artifact_management.source_code_manager import (
+    MirrorSpec,
+    RefType,
+)
+from dd_license_attribution.metadata_collector.strategies.override_strategy import (
+    OverrideCollectionStrategy,
+    OverrideRule,
+)
+
+
+class JsonConfigParser:
+    """Parser for JSON configuration files used by dd-license-attribution."""
+
+    @staticmethod
+    def parse_ref_mapping(
+        ref_mapping_dict: dict[str, str],
+    ) -> dict[tuple[RefType, str], tuple[RefType, str]]:
+        """Parse ref_mapping from JSON format to the expected tuple format.
+
+        JSON format: {"branch:main": "branch:stephofx_eval-scripts"}
+        Expected format: {(RefType.BRANCH, "main"): (RefType.BRANCH, "stephofx_eval-scripts")}
+
+        Args:
+            ref_mapping_dict: Dictionary with string keys and values in format "type:name"
+
+        Returns:
+            Dictionary with tuple keys and values representing (RefType, name) pairs
+
+        Raises:
+            ValueError: If the format is invalid or RefType is not recognized
+        """
+        parsed_mapping = {}
+        for key, value in ref_mapping_dict.items():
+            # Parse key: "branch:main" -> (RefType.BRANCH, "main")
+            key_parts = key.split(":", 1)
+            if len(key_parts) != 2:
+                raise ValueError(
+                    f"Invalid ref mapping key format: {key}. Expected format: 'type:name'"
+                )
+            key_type_str, key_name = key_parts
+            try:
+                key_type = RefType(key_type_str)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid ref type in key: {key_type_str}. Valid types: {[t.value for t in RefType]}"
+                )
+
+            # Parse value: "branch:stephofx_eval-scripts" -> (RefType.BRANCH, "stephofx_eval-scripts")
+            value_parts = value.split(":", 1)
+            if len(value_parts) != 2:
+                raise ValueError(
+                    f"Invalid ref mapping value format: {value}. Expected format: 'type:name'"
+                )
+            value_type_str, value_name = value_parts
+            try:
+                value_type = RefType(value_type_str)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid ref type in value: {value_type_str}. Valid types: {[t.value for t in RefType]}"
+                )
+
+            parsed_mapping[(key_type, key_name)] = (value_type, value_name)
+
+        return parsed_mapping
+
+    @staticmethod
+    def load_mirror_configs(mirror_file_path: str) -> list[MirrorSpec]:
+        """Load mirror configurations from a JSON file.
+
+        Args:
+            mirror_file_path: Path to the JSON file containing mirror specifications
+
+        Returns:
+            List of MirrorSpec objects
+
+        Raises:
+            FileNotFoundError: If the mirror configuration file is not found
+            json.JSONDecodeError: If the JSON file is invalid
+            ValueError: If the mirror configuration format is invalid
+        """
+        try:
+            mirror_configs = json.loads(open_file(mirror_file_path))
+            mirrors = []
+            for config in mirror_configs:
+                ref_mapping = None
+                if config.get("ref_mapping"):
+                    ref_mapping = JsonConfigParser.parse_ref_mapping(
+                        config["ref_mapping"]
+                    )
+                mirrors.append(
+                    MirrorSpec(
+                        original_url=config["original_url"],
+                        mirror_url=config["mirror_url"],
+                        ref_mapping=ref_mapping,
+                    )
+                )
+            return mirrors
+        except FileNotFoundError:
+            logging.error(f"Mirror configuration file not found: {mirror_file_path}")
+            raise
+        except json.JSONDecodeError:
+            logging.error(
+                f"Invalid JSON in mirror configuration file: {mirror_file_path}"
+            )
+            raise
+        except Exception as e:
+            logging.error(f"Failed to load mirror configurations: {str(e)}")
+            raise
+
+    @staticmethod
+    def load_override_configs(override_file_path: str) -> list[OverrideRule]:
+        """Load override configurations from a JSON file.
+
+        Args:
+            override_file_path: Path to the JSON file containing override specifications
+
+        Returns:
+            List of override rules
+
+        Raises:
+            FileNotFoundError: If the override configuration file is not found
+            json.JSONDecodeError: If the JSON file is invalid
+            ValueError: If the override configuration format is invalid
+        """
+        try:
+            override_rules_json = json.loads(open_file(override_file_path))
+            override_rules = OverrideCollectionStrategy.json_to_override_rules(
+                override_rules_json
+            )
+            return override_rules
+        except FileNotFoundError:
+            logging.error(f"Override spec file not found: {override_file_path}")
+            raise
+        except json.JSONDecodeError:
+            logging.error(f"Invalid JSON in override spec file: {override_file_path}")
+            raise
+        except Exception as e:
+            logging.error(f"Error reading override spec file: {e}")
+            raise

--- a/tests/unit/test_json_config_parser.py
+++ b/tests/unit/test_json_config_parser.py
@@ -1,0 +1,160 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2024-present Datadog, Inc.
+
+import json
+import tempfile
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dd_license_attribution.artifact_management.source_code_manager import RefType
+from dd_license_attribution.config.json_config_parser import JsonConfigParser
+from dd_license_attribution.metadata_collector.strategies.override_strategy import (
+    OverrideRule,
+    OverrideTargetField,
+    OverrideType,
+)
+
+
+class TestJsonConfigParser:
+    def test_parse_ref_mapping_valid(self) -> None:
+        """Test parsing valid ref mapping."""
+        ref_mapping_dict = {
+            "branch:main": "branch:stephofx_eval-scripts",
+            "tag:v1.0": "branch:development",
+        }
+
+        result = JsonConfigParser.parse_ref_mapping(ref_mapping_dict)
+
+        expected = {
+            (RefType.BRANCH, "main"): (RefType.BRANCH, "stephofx_eval-scripts"),
+            (RefType.TAG, "v1.0"): (RefType.BRANCH, "development"),
+        }
+        assert result == expected
+
+    def test_parse_ref_mapping_invalid_key_format(self) -> None:
+        """Test parsing ref mapping with invalid key format."""
+        ref_mapping_dict = {"invalid_key": "branch:main"}
+
+        with pytest.raises(ValueError, match="Invalid ref mapping key format"):
+            JsonConfigParser.parse_ref_mapping(ref_mapping_dict)
+
+    def test_parse_ref_mapping_invalid_value_format(self) -> None:
+        """Test parsing ref mapping with invalid value format."""
+        ref_mapping_dict = {"branch:main": "invalid_value"}
+
+        with pytest.raises(ValueError, match="Invalid ref mapping value format"):
+            JsonConfigParser.parse_ref_mapping(ref_mapping_dict)
+
+    def test_parse_ref_mapping_invalid_ref_type(self) -> None:
+        """Test parsing ref mapping with invalid ref type."""
+        ref_mapping_dict = {"invalid:main": "branch:main"}
+
+        with pytest.raises(ValueError, match="Invalid ref type in key"):
+            JsonConfigParser.parse_ref_mapping(ref_mapping_dict)
+
+    @patch("dd_license_attribution.config.json_config_parser.open_file")
+    def test_load_mirror_configs_valid(self, mock_open_file: Mock) -> None:
+        """Test loading valid mirror configurations."""
+        mock_open_file.return_value = json.dumps(
+            [
+                {
+                    "original_url": "https://github.com/DataDog/test",
+                    "mirror_url": "https://github.com/mirror/test",
+                    "ref_mapping": {"branch:main": "branch:development"},
+                }
+            ]
+        )
+
+        mirrors = JsonConfigParser.load_mirror_configs("test.json")
+
+        assert len(mirrors) == 1
+        mirror = mirrors[0]
+        assert mirror.original_url == "https://github.com/DataDog/test"
+        assert mirror.mirror_url == "https://github.com/mirror/test"
+        assert mirror.ref_mapping == {
+            (RefType.BRANCH, "main"): (RefType.BRANCH, "development")
+        }
+
+    @patch("dd_license_attribution.config.json_config_parser.open_file")
+    def test_load_mirror_configs_no_ref_mapping(self, mock_open_file: Mock) -> None:
+        """Test loading mirror configurations without ref mapping."""
+        mock_open_file.return_value = json.dumps(
+            [
+                {
+                    "original_url": "https://github.com/DataDog/test",
+                    "mirror_url": "https://github.com/mirror/test",
+                }
+            ]
+        )
+
+        mirrors = JsonConfigParser.load_mirror_configs("test.json")
+
+        assert len(mirrors) == 1
+        mirror = mirrors[0]
+        assert mirror.original_url == "https://github.com/DataDog/test"
+        assert mirror.mirror_url == "https://github.com/mirror/test"
+        assert mirror.ref_mapping is None
+
+    @patch("dd_license_attribution.config.json_config_parser.open_file")
+    def test_load_mirror_configs_file_not_found(self, mock_open_file: Mock) -> None:
+        """Test loading mirror configurations with file not found."""
+        mock_open_file.side_effect = FileNotFoundError("File not found")
+
+        with pytest.raises(FileNotFoundError):
+            JsonConfigParser.load_mirror_configs("nonexistent.json")
+
+    @patch("dd_license_attribution.config.json_config_parser.open_file")
+    def test_load_mirror_configs_invalid_json(self, mock_open_file: Mock) -> None:
+        """Test loading mirror configurations with invalid JSON."""
+        mock_open_file.return_value = "invalid json"
+
+        with pytest.raises(json.JSONDecodeError):
+            JsonConfigParser.load_mirror_configs("test.json")
+
+    @patch("dd_license_attribution.config.json_config_parser.open_file")
+    def test_load_override_configs_valid(self, mock_open_file: Mock) -> None:
+        """Test loading valid override configurations."""
+        mock_open_file.return_value = json.dumps(
+            [
+                {
+                    "override_type": "add",
+                    "target": {"component": "test-component"},
+                    "replacement": {
+                        "name": "new-component",
+                        "origin": "new-origin",
+                        "version": "1.0.0",
+                        "license": ["MIT"],
+                        "copyright": ["Copyright 2024"],
+                    },
+                }
+            ]
+        )
+
+        override_rules = JsonConfigParser.load_override_configs("test.json")
+
+        assert len(override_rules) == 1
+        rule = override_rules[0]
+        assert isinstance(rule, OverrideRule)
+        assert rule.override_type == OverrideType.ADD
+        assert rule.target[OverrideTargetField.COMPONENT] == "test-component"
+        assert rule.replacement is not None
+        assert rule.replacement.name == "new-component"
+
+    @patch("dd_license_attribution.config.json_config_parser.open_file")
+    def test_load_override_configs_file_not_found(self, mock_open_file: Mock) -> None:
+        """Test loading override configurations with file not found."""
+        mock_open_file.side_effect = FileNotFoundError("File not found")
+
+        with pytest.raises(FileNotFoundError):
+            JsonConfigParser.load_override_configs("nonexistent.json")
+
+    @patch("dd_license_attribution.config.json_config_parser.open_file")
+    def test_load_override_configs_invalid_json(self, mock_open_file: Mock) -> None:
+        """Test loading override configurations with invalid JSON."""
+        mock_open_file.return_value = "invalid json"
+
+        with pytest.raises(json.JSONDecodeError):
+            JsonConfigParser.load_override_configs("test.json")

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -121,7 +121,7 @@ def test_missing_package() -> None:
     assert "Missing argument 'PACKAGE'." in result.stderr
 
 
-@patch("dd_license_attribution.cli.main_cli.open_file")
+@patch("dd_license_attribution.config.json_config_parser.open_file")
 @patch("dd_license_attribution.cli.main_cli.GitHub")
 @patch("dd_license_attribution.cli.main_cli.SourceCodeManager")
 @patch("dd_license_attribution.cli.main_cli.PythonEnvManager")
@@ -150,7 +150,7 @@ def test_use_mirrors_invalid_json(
     assert "Invalid JSON in mirror configuration file: test.json" in result.stderr
 
 
-@patch("dd_license_attribution.cli.main_cli.open_file")
+@patch("dd_license_attribution.config.json_config_parser.open_file")
 @patch("dd_license_attribution.cli.main_cli.GitHub")
 @patch("dd_license_attribution.cli.main_cli.SourceCodeManager")
 @patch("dd_license_attribution.cli.main_cli.PythonEnvManager")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

The branch-spec is not correctly validated and loaded from the json file.
To address it, we added better type validation.
To simplify code readability all json configurations that are parsing  in main.cli were extracted to a new config parsing class.

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->

Using the following remap will fail in the previous version:
```
[
    {
        "original_url": "https://github.com/DataDog/ARFBench",
        "mirror_url": "https://github.com/DataDog/ARFBench",
        "ref_mapping": {
            "branch:main": "branch:stephofx_eval-scripts",
            "tag:v1.0": "branch:stephofx_eval-scripts"
        }
    }
]
```
A DEBUG line will state that the mirror is detected but point to the main branch in place of the referenced one. 
After this change, it will say both are correctly referenced.