### PR TITLE
[OSPO-391] Avoid debug noisy log messages from third party dependencies

### DIFF
--- a/src/dd_license_attribution/config/json_config_parser.py
+++ b/src/dd_license_attribution/config/json_config_parser.py
@@ -5,6 +5,9 @@
 
 import json
 import logging
+
+# Get application-specific logger
+logger = logging.getLogger("dd_license_attribution")
 from typing import Optional
 
 from dd_license_attribution.adaptors.os import open_file
@@ -106,15 +109,15 @@ class JsonConfigParser:
                 )
             return mirrors
         except FileNotFoundError:
-            logging.error(f"Mirror configuration file not found: {mirror_file_path}")
+            logger.error(f"Mirror configuration file not found: {mirror_file_path}")
             raise
         except json.JSONDecodeError:
-            logging.error(
+            logger.error(
                 f"Invalid JSON in mirror configuration file: {mirror_file_path}"
             )
             raise
         except Exception as e:
-            logging.error(f"Failed to load mirror configurations: {str(e)}")
+            logger.error(f"Failed to load mirror configurations: {str(e)}")
             raise
 
     @staticmethod
@@ -139,11 +142,11 @@ class JsonConfigParser:
             )
             return override_rules
         except FileNotFoundError:
-            logging.error(f"Override spec file not found: {override_file_path}")
+            logger.error(f"Override spec file not found: {override_file_path}")
             raise
         except json.JSONDecodeError:
-            logging.error(f"Invalid JSON in override spec file: {override_file_path}")
+            logger.error(f"Invalid JSON in override spec file: {override_file_path}")
             raise
         except Exception as e:
-            logging.error(f"Error reading override spec file: {e}")
+            logger.error(f"Error reading override spec file: {e}")
             raise

--- a/src/dd_license_attribution/metadata_collector/license_checker.py
+++ b/src/dd_license_attribution/metadata_collector/license_checker.py
@@ -4,6 +4,9 @@
 # Copyright 2024-present Datadog, Inc.
 
 import logging
+
+# Get application-specific logger
+logger = logging.getLogger("dd_license_attribution")
 from typing import List
 
 from dd_license_attribution.metadata_collector.metadata import Metadata
@@ -25,7 +28,7 @@ class LicenseChecker:
                     msg = "Package {} has a license ({}) that is in the list of cautionary licenses. Double check that the license is compatible with your project.".format(
                         metadata.name, license_text
                     )
-                    logging.warning(msg)
+                    logger.warning(msg)
 
     def _is_cautionary_license(self, license_text: str) -> bool:
         license_text_upper = license_text.upper()

--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -7,6 +7,9 @@
 
 import json
 import logging
+
+# Get application-specific logger
+logger = logging.getLogger("dd_license_attribution")
 from typing import Any, Dict, List
 
 import requests
@@ -48,14 +51,14 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
         all_deps: Dict[str, str] = {}
 
         if "packages" not in lock_data:
-            logging.warning("No 'packages' key found in package-lock.json.")
+            logger.warning("No 'packages' key found in package-lock.json.")
             return all_deps
 
         packages = lock_data["packages"]
         # Find the root package key
         root_key = "" if "" in packages else "./" if "./" in packages else None
         if root_key is None:
-            logging.warning(
+            logger.warning(
                 "A root package wasn't found. Collecting NodeJS dependencies from none NodeJS projects is not supported yet."
             )
             return all_deps
@@ -111,17 +114,17 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
                 "npm install --package-lock-only --force; cd $CWD"
             )
         except Exception as e:
-            logging.warning(f"Failed to run npm install for {self.top_package}: {e}")
+            logger.warning(f"Failed to run npm install for {self.top_package}: {e}")
             return updated_metadata
         lock_path = path_join(project_path, "package-lock.json")
         lock_data = {}
         if not path_exists(lock_path):
-            logging.warning(f"No package-lock.json found in {project_path}")
+            logger.warning(f"No package-lock.json found in {project_path}")
             return updated_metadata
         try:
             lock_data = json.loads(open_file(lock_path))
         except Exception as e:
-            logging.warning(f"Failed to read package-lock.json: {e}")
+            logger.warning(f"Failed to read package-lock.json: {e}")
             return updated_metadata
 
         all_deps = self._extract_all_dependencies(lock_data)
@@ -173,12 +176,12 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
                     ):
                         homepage_url = pkg_data["homepage"]
                 else:
-                    logging.warning(
+                    logger.warning(
                         f"Failed to fetch npm registry metadata for "
                         f"{dep_name}@{version}: {resp.status_code}, {resp.text}"
                     )
             except Exception as e:
-                logging.warning(
+                logger.warning(
                     f"Failed to fetch npm registry metadata for "
                     f"{dep_name}@{version}: {e}"
                 )

--- a/src/dd_license_attribution/metadata_collector/strategies/pypi_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/pypi_collection_strategy.py
@@ -4,6 +4,9 @@
 # Copyright 2024-present Datadog, Inc.
 
 import logging
+
+# Get application-specific logger
+logger = logging.getLogger("dd_license_attribution")
 from typing import Any, Dict, Optional
 
 import requests
@@ -52,7 +55,7 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
         if dependencies is None:
             return updated_metadata
         for dependency, version in dependencies:
-            logging.debug(f"dependency: {dependency}, version: {version}")
+            logger.debug(f"dependency: {dependency}, version: {version}")
 
             # get the metadata from pypi API
             pypi_metadata = self._get_metadata_from_pypi(dependency, version)
@@ -63,8 +66,8 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
             else:
                 pypi_info = {"name": dependency}
 
-            logging.debug(f"pypi_info: {pypi_info}")
-            logging.debug(f"pypi_metadata: {pypi_metadata}")
+            logger.debug(f"pypi_info: {pypi_info}")
+            logger.debug(f"pypi_metadata: {pypi_metadata}")
 
             origin = "pypi:" + dependency
             project_urls = {}
@@ -74,7 +77,7 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
 
             for key in list(project_urls):
                 if project_urls[key] is None:
-                    logging.debug(
+                    logger.debug(
                         f"Project URL for key '{key}' is None in package {dependency}"
                     )
                     del project_urls[key]
@@ -168,10 +171,10 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
         request_uri = f"https://pypi.org/pypi/{package}/{version}/json"
         response = requests.get(request_uri)
         if response.status_code == 404:
-            logging.warning(f"pypi.org is returning a 404 for {package}. Skipping.")
+            logger.warning(f"pypi.org is returning a 404 for {package}. Skipping.")
             return None
         if response.status_code == 503:
-            logging.warning(f"pypi.org is returning a 503 for{package}. Skipping.")
+            logger.warning(f"pypi.org is returning a 503 for{package}. Skipping.")
             return None
         return response.json()  # type: ignore
 

--- a/src/dd_license_attribution/metadata_collector/strategies/scan_code_toolkit_metadata_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/scan_code_toolkit_metadata_collection_strategy.py
@@ -4,6 +4,9 @@
 # Copyright 2024-present Datadog, Inc.
 
 import logging
+
+# Get application-specific logger
+logger = logging.getLogger("dd_license_attribution")
 import warnings
 
 # Suppress the libmagic warning from typecode
@@ -82,7 +85,7 @@ class ScanCodeToolkitMetadataCollectionStrategy(MetadataCollectionStrategy):
                         or not path_exists(source_code_reference.local_root_path)
                     )
                 ):
-                    logging.warning(
+                    logger.warning(
                         f"{source_code_reference.local_full_path} does not exist, skipping. "
                         f"This may be due to the package manager not providing the correct source code location on {package.local_src_path}."
                     )

--- a/src/dd_license_attribution/utils/logging.py
+++ b/src/dd_license_attribution/utils/logging.py
@@ -1,6 +1,8 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
 #
-# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
 # Copyright 2024-present Datadog, Inc.
 import logging
 import sys
@@ -37,10 +39,13 @@ def setup_logging(level: int) -> None:
     console_handler = logging.StreamHandler(sys.stderr)
     console_handler.setFormatter(formatter)
 
-    # Configure root logger
+    # Configure root logger - set to INFO to suppress third-party debug logs
     root_logger = logging.getLogger()
-    root_logger.setLevel(level)
+    root_logger.setLevel(logging.INFO if level == logging.DEBUG else level)
     root_logger.addHandler(console_handler)
+
+    app_logger = logging.getLogger("dd_license_attribution")
+    app_logger.setLevel(level)
 
     # Prevent propagation to avoid duplicate logs
     root_logger.propagate = False

--- a/tests/unit/test_license_checker.py
+++ b/tests/unit/test_license_checker.py
@@ -88,7 +88,9 @@ def test_check_cautionary_licenses_with_non_cautionary_license() -> None:
         mock_is_cautionary.return_value = False
         checker.check_cautionary_licenses([metadata])
         mock_is_cautionary.assert_called_once_with("MIT")
-        with patch("logging.warning") as mock_logging:
+        with patch(
+            "dd_license_attribution.metadata_collector.license_checker.logger.warning"
+        ) as mock_logging:
             mock_logging.assert_not_called()
 
 
@@ -105,7 +107,9 @@ def test_check_cautionary_licenses_with_cautionary_license() -> None:
     checker = LicenseChecker(default_config.preset_cautionary_licenses)
     with patch.object(checker, "_is_cautionary_license") as mock_is_cautionary:
         mock_is_cautionary.return_value = True
-        with patch("logging.warning") as mock_logging:
+        with patch(
+            "dd_license_attribution.metadata_collector.license_checker.logger.warning"
+        ) as mock_logging:
             checker.check_cautionary_licenses([metadata])
             mock_is_cautionary.assert_called_once_with("GPL-3.0")
             mock_logging.assert_called_once()
@@ -124,7 +128,9 @@ def test_check_cautionary_licenses_with_multiple_licenses() -> None:
     checker = LicenseChecker(default_config.preset_cautionary_licenses)
     with patch.object(checker, "_is_cautionary_license") as mock_is_cautionary:
         mock_is_cautionary.side_effect = [False, True, False]
-        with patch("logging.warning") as mock_logging:
+        with patch(
+            "dd_license_attribution.metadata_collector.license_checker.logger.warning"
+        ) as mock_logging:
             checker.check_cautionary_licenses([metadata])
             assert mock_is_cautionary.call_count == 3
             mock_logging.assert_called_once()
@@ -146,7 +152,9 @@ def test_check_cautionary_licenses_with_all_cautionary_keywords() -> None:
     checker = LicenseChecker(default_config.preset_cautionary_licenses)
     with patch.object(checker, "_is_cautionary_license") as mock_is_cautionary:
         mock_is_cautionary.return_value = True
-        with patch("logging.warning") as mock_logging:
+        with patch(
+            "dd_license_attribution.metadata_collector.license_checker.logger.warning"
+        ) as mock_logging:
             checker.check_cautionary_licenses(metadata_list)
             assert mock_is_cautionary.call_count == len(
                 default_config.preset_cautionary_licenses


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [X] Bug Fix
- [ ] Documentation Update

## Description

Right now, when trying to debug a problem with dd-license-attribution using DEBUG log level, a lot of noise is coming to the logs from third party dependencies, making this unusable.

This PR uses `INFO` level for all third party dependencies, when using `debug` for our app, while keeping the rest of the levels intact.

