### PR TITLE
[OSPO-388] Skips the NPM strategy for projects using workspaces with a warning

### DIFF
--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -107,6 +107,13 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
         if not path_exists(package_json_path):
             return updated_metadata
 
+        package_json_data = json.loads(open_file(package_json_path))
+        if "workspaces" in package_json_data:
+            logger.warning(
+                f"Node projects using workspaces are not supported yet by the NPM collection strategy."
+            )
+            return updated_metadata
+
         # Run npm install --package-lock-only to generate package-lock.json
         try:
             output_from_command(


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Some node projects (in particular some that use a modern version of Yarn) might use the workspaces functionality to be able to generate several packages out of a monorepo. 

When trying to run `npm` against these projects, they will fail. 

This PR adds a warning an skips the `npm` strategy while we work on a fix that includes using `yarn` as failover.

