### PR TITLE
[OSPO-394] Refactor the NPM strategy in preparation to add a yarn.lock fallback

### DIFF
--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -47,6 +47,136 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
             project_scope == ProjectScope.ONLY_TRANSITIVE_DEPENDENCIES
         )
 
+    def _clean_version_string(self, version: str) -> str:
+        if isinstance(version, str) and version:
+            if version.startswith(">="):
+                return version[2:]
+            elif version and version[0] in {"^", "~", ">"}:
+                return version[1:]
+        return version
+
+    def _extract_license_from_pkg_data(self, pkg_data: Dict[str, Any]) -> List[str]:
+        if "license" in pkg_data and pkg_data["license"]:
+            return [str(pkg_data["license"])]
+        return []
+
+    def _extract_copyright_from_pkg_data(self, pkg_data: Dict[str, Any]) -> List[str]:
+        if "author" not in pkg_data or not pkg_data["author"]:
+            return []
+
+        author = pkg_data["author"]
+        if isinstance(author, dict) and "name" in author:
+            return [str(author["name"])]
+        elif isinstance(author, str):
+            return [author]
+        return []
+
+    def _fetch_npm_registry_metadata(
+        self, dep_name: str, version: str
+    ) -> tuple[List[str], List[str], Dict[str, Any] | None]:
+        license = []
+        copyright = []
+        pkg_data = None
+
+        try:
+            resp = requests.get(
+                f"https://registry.npmjs.org/{dep_name}/{version}",
+                timeout=5,
+            )
+            if resp.status_code == 200:
+                pkg_data = resp.json()
+                license = self._extract_license_from_pkg_data(pkg_data)
+                copyright = self._extract_copyright_from_pkg_data(pkg_data)
+            else:
+                logging.warning(
+                    "Failed to fetch npm registry metadata for "
+                    f"{dep_name}@{version}: {resp.status_code}, "
+                    f"{resp.text}"
+                )
+        except Exception as e:
+            logging.warning(
+                "Failed to fetch npm registry metadata for "
+                f"{dep_name}@{version}: {e}"
+            )
+
+        return license, copyright, pkg_data
+
+    def _determine_origin(
+        self,
+        pkg_data: Dict[str, Any] | None,
+        dep_name: str,
+    ) -> str:
+        if not pkg_data:
+            return f"npm:{dep_name}"
+
+        # Extract repository URL
+        repository_url = None
+        if "repository" in pkg_data and pkg_data["repository"]:
+            repo = pkg_data["repository"]
+            if isinstance(repo, dict) and "url" in repo:
+                repository_url = repo["url"]
+            elif isinstance(repo, str):
+                repository_url = repo
+
+        if repository_url:
+            return str(repository_url)
+
+        # Extract homepage URL as fallback
+        if "homepage" in pkg_data and pkg_data["homepage"]:
+            return str(pkg_data["homepage"])
+
+        return f"npm:{dep_name}"
+
+    def _enrich_metadata_with_npm_registry(
+        self, metadata: List[Metadata], dependencies: Dict[str, str]
+    ) -> List[Metadata]:
+        updated_metadata = metadata.copy()
+
+        # Apply project scope filters - filter transitive-only if needed
+        if self.only_transitive:
+            updated_metadata = [
+                m for m in updated_metadata if m.name != self.top_package
+            ]
+
+        for dep_name, version in dependencies.items():
+            clean_version = self._clean_version_string(version)
+
+            license, copyright, pkg_data = self._fetch_npm_registry_metadata(
+                dep_name, clean_version
+            )
+
+            origin = self._determine_origin(pkg_data, dep_name)
+
+            found = False
+            for meta in updated_metadata:
+                if meta.name == dep_name:
+                    found = True
+                    if (
+                        not meta.origin or not validate_git_url(meta.origin)
+                    ) and origin:
+                        meta.origin = origin
+                    if not meta.license and license:
+                        meta.license = license
+                    if not meta.copyright and copyright:
+                        meta.copyright = copyright
+                    if not meta.version and clean_version:
+                        meta.version = clean_version
+                    break
+
+            if not found:
+                updated_metadata.append(
+                    Metadata(
+                        name=dep_name,
+                        version=clean_version,
+                        origin=origin,
+                        local_src_path=None,
+                        license=license,
+                        copyright=copyright,
+                    )
+                )
+
+        return updated_metadata
+
     def _extract_all_dependencies(self, lock_data: Dict[str, Any]) -> Dict[str, str]:
         all_deps: Dict[str, str] = {}
 
@@ -114,6 +244,10 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
             )
             return updated_metadata
 
+        # Early return for ONLY_ROOT_PROJECT - no need to run npm install
+        if self.only_root_project:
+            return updated_metadata
+
         # Run npm install --package-lock-only to generate package-lock.json
         try:
             output_from_command(
@@ -136,94 +270,6 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
 
         all_deps = self._extract_all_dependencies(lock_data)
 
-        if self.only_root_project:
-            return updated_metadata
-        if self.only_transitive:
-            updated_metadata = [
-                m for m in updated_metadata if m.name != self.top_package
-            ]
-        for dep_name, version in all_deps.items():
-            # Remove ^, ~, >, or >= from version if present
-            if isinstance(version, str) and version:
-                if version.startswith(">="):
-                    version = version[2:]
-                elif version[0] in {"^", "~", ">"}:
-                    version = version[1:]
-            # Fetch metadata from npmjs registry API
-            license = []
-            copyright = []
-            repository_url = None
-            homepage_url = None
-            try:
-                resp = requests.get(
-                    f"https://registry.npmjs.org/{dep_name}/{version}", timeout=5
-                )
-                if resp.status_code == 200:
-                    pkg_data = resp.json()
-                    if "license" in pkg_data and pkg_data["license"]:
-                        license = [str(pkg_data["license"])]
-                    if "author" in pkg_data and pkg_data["author"]:
-                        if (
-                            isinstance(pkg_data["author"], dict)
-                            and "name" in pkg_data["author"]
-                        ):
-                            copyright = [str(pkg_data["author"]["name"])]
-                        elif isinstance(pkg_data["author"], str):
-                            copyright = [pkg_data["author"]]
-                    if "repository" in pkg_data and pkg_data["repository"]:
-                        repo = pkg_data["repository"]
-                        if isinstance(repo, dict) and "url" in repo:
-                            repository_url = repo["url"]
-                        elif isinstance(repo, str):
-                            repository_url = repo
-                    if (
-                        not repository_url
-                        and "homepage" in pkg_data
-                        and pkg_data["homepage"]
-                    ):
-                        homepage_url = pkg_data["homepage"]
-                else:
-                    logger.warning(
-                        f"Failed to fetch npm registry metadata for "
-                        f"{dep_name}@{version}: {resp.status_code}, {resp.text}"
-                    )
-            except Exception as e:
-                logger.warning(
-                    f"Failed to fetch npm registry metadata for "
-                    f"{dep_name}@{version}: {e}"
-                )
-            # Set origin: prefer repository, then homepage, then npm:{name}
-            if repository_url:
-                origin = repository_url
-            elif homepage_url:
-                origin = homepage_url
-            else:
-                origin = f"npm:{dep_name}"
-            found = False
-            for meta in updated_metadata:
-                if meta.name == dep_name:
-                    found = True
-                    # Update origin if not a valid git url or missing
-                    if (
-                        not meta.origin or not validate_git_url(meta.origin)
-                    ) and origin:
-                        meta.origin = origin
-                    if not meta.license and license:
-                        meta.license = license
-                    if not meta.copyright and copyright:
-                        meta.copyright = copyright
-                    if not meta.version and version:
-                        meta.version = version
-                    break
-            if not found:
-                updated_metadata.append(
-                    Metadata(
-                        name=dep_name,
-                        version=version,
-                        origin=origin,
-                        local_src_path=None,
-                        license=license,
-                        copyright=copyright,
-                    )
-                )
-        return updated_metadata
+        # Use private method to enrich metadata with NPM registry data
+        # Handles scope filtering, version cleaning, fetching, and enrichment
+        return self._enrich_metadata_with_npm_registry(updated_metadata, all_deps)

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -150,12 +150,10 @@ def test_npm_collection_strategy_is_bypassed_if_only_root_project(
     ]
     result = strategy.augment_metadata(initial_metadata)
     assert result == initial_metadata
-    mock_output_from_command.assert_called_once_with(
-        f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
-    )
-    assert mock_exists.call_count == 2
-    assert mock_path_join.call_count == 2
-    assert mock_open.call_count == 2
+    mock_output_from_command.assert_not_called()
+    assert mock_exists.call_count == 1
+    assert mock_path_join.call_count == 1
+    assert mock_open.call_count == 1
     mock_requests.assert_not_called()
 
 

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -771,3 +771,82 @@ def test_npm_collection_strategy_handles_workspaces(
     mock_open.assert_called_once()
     mock_output_from_command.assert_not_called()
     mock_requests.assert_not_called()
+
+
+def test_clean_version_string() -> None:
+    """Test _clean_version_string with various version string formats."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    test_cases = {
+        # Basic prefix removals
+        "^1.2.3": "1.2.3",
+        "~1.2.3": "1.2.3",
+        ">1.2.3": "1.2.3",
+        ">=1.2.3": "1.2.3",
+        # Plain version unchanged
+        "1.2.3": "1.2.3",
+        # Empty string
+        "": "",
+        # Pre-release versions
+        "^1.2.3-alpha.1": "1.2.3-alpha.1",
+        "~2.0.0-beta": "2.0.0-beta",
+        # Build metadata
+        ">=1.0.0+build.1": "1.0.0+build.1",
+        # Edge cases with only prefixes
+        "^": "",
+        "~": "",
+        ">": "",
+        ">=": "",
+        # Priority test - >= should be handled first, not just >
+        ">=1.0.0": "1.0.0",
+    }
+
+    for input_version, expected_output in test_cases.items():
+        result = strategy._clean_version_string(input_version)
+        assert (
+            result == expected_output
+        ), f"Failed for '{input_version}': expected '{expected_output}', got '{result}'"
+
+
+def test_extract_copyright_from_pkg_data() -> None:
+    """Test _extract_copyright_from_pkg_data with various author formats."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    test_cases = {
+        # Author as string
+        '{"author": "John Doe"}': ["John Doe"],
+        '{"author": "Jane Smith <jane@example.com>"}': [
+            "Jane Smith <jane@example.com>"
+        ],
+        # Author as dict with name
+        '{"author": {"name": "Alice Cooper"}}': ["Alice Cooper"],
+        '{"author": {"name": "Bob Wilson", "email": "bob@example.com"}}': [
+            "Bob Wilson"
+        ],
+        # Missing author key
+        "{}": [],
+        '{"license": "MIT"}': [],
+        # Author is None or empty
+        '{"author": null}': [],
+        '{"author": ""}': [],
+        # Author as dict without name
+        '{"author": {"email": "test@example.com"}}': [],
+        '{"author": {"url": "https://example.com"}}': [],
+        # Author as other types
+        '{"author": []}': [],
+        '{"author": 123}': [],
+        '{"author": true}': [],
+    }
+
+    for test_input, expected_output in test_cases.items():
+        pkg_data = json.loads(test_input)
+        result = strategy._extract_copyright_from_pkg_data(pkg_data)
+        assert (
+            result == expected_output
+        ), f"Failed for '{test_input}': expected '{expected_output}', got '{result}'"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Most of the code related to get attribution from Node dependencies will be common, whether using `package-lock.json`, or `yarn.lock`.

For that reason, and in preparation to add the `yarn.lock` fallback for projects using `yarn` specific features, I have refactored the npm strategy, moving some of this common functionality to their methods, and adding some specific tests for them.


