### PR TITLE
handle more UTF encodings- utf 16, and whatever the system setting is

### DIFF
--- a/src/dd_license_attribution/adaptors/os.py
+++ b/src/dd_license_attribution/adaptors/os.py
@@ -42,8 +42,16 @@ def get_current_working_directory() -> str:
 
 
 def open_file(file_path: str) -> str:
-    with open(file_path, "r") as file:
-        return file.read()
+    try:
+        with open(file_path, "r", encoding="utf-8") as file:
+            return file.read()
+    except UnicodeDecodeError:
+        try:
+            with open(file_path, "r", encoding="utf-16") as file:
+                return file.read()
+        except UnicodeDecodeError:
+            with open(file_path, "r", encoding=None) as file:
+                return file.read()
 
 
 def path_join(path: str, *paths: str) -> str:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

With this change, the code will now handle more UTF encodings. It starts by trying UTF-8 which is most common, then tries UTF-16, and if both of those fail, tries whatever encoding is the system's default.

## Related tickets & Documents

This Slack message:
https://dd.slack.com/archives/C076FS5C73J/p1758573709744859

## How to reproduce and testing

Running dd-license-attribution on https://github.com/DataDog/datadog-sbom-generator/ doesn't work with the old code, and does with this
