### PR TITLE
new util for custom splitting of copyright metadata- currently used in 1 strategy

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -52,7 +52,7 @@
 "pefile","https://github.com/erocarrera/pefile","['MIT']","['Ero Carrera']"
 "pip","https://github.com/pypa/pip","['MIT']","['Andrey Petrov and contributors', 'Corporation for National Research Initiatives', 'Eric Larson', 'INADA Naoki', 'Kim Davies and contributors', 'Python Software Foundation', 'Seth Michael Larson', 'Stephen Rosen', 'Stichting Mathematisch Centrum Amsterdam, The Netherlands', 'Taneli Hukkinen', 'The pip developers', 'The platformdirs developers', 'Thomas Kluyver', 'Tzu-ping Chung', 'Will McGugan']"
 "pip-requirements-parser","https://github.com/nexB/pip-requirements-parser","['MIT']","['The pip authors', 'nexB. Inc. and others']"
-"pkginfo2","https://github.com/nexB/pkginfo2","['MIT']","['Agendaless Consulting', 'Inc. Authored by Tres Seaver', 'Maintained by nexB']"
+"pkginfo2","https://github.com/nexB/pkginfo2","['MIT']","['Agendaless Consulting', 'Maintained by nexB, Inc. Authored by Tres Seaver']"
 "pluggy","https://github.com/pytest-dev/pluggy","['MIT']","['Holger Krekel']"
 "plugincode","https://github.com/nexB/plugincode","['Apache-2.0']","['nexB. Inc. and others']"
 "ply","https://www.dabeaz.com/ply/","['BSD']","['David Beazley']"

--- a/README.md
+++ b/README.md
@@ -95,9 +95,13 @@ The tool generates a CSV file with the following columns:
 Example output:
 ```csv
 Component,Origin,License,Copyright
-aiohttp,https://github.com/aio-libs/aiohttp,Apache-2.0,"Copyright (c) 2013-present aio-libs"
-requests,https://github.com/psf/requests,Apache-2.0,"Copyright 2019 Kenneth Reitz"
+aiohttp,https://github.com/aio-libs/aiohttp,Apache-2.0,"aio-libs"
+requests,https://github.com/psf/requests,Apache-2.0,"Kenneth Reitz"
 ```
+
+#### Output string configuration
+
+There's a file at `src/dd_license_attribution/config/string_formatting_config.py` that you can customize. It's used to help formatting of the "Copyright" part of the output. These are strings that often come after a comma (like the Inc in "Datadog, Inc.") that should be exceptions to splitting the string on the comma. 
 
 #### Manual repository override configuration
 

--- a/src/dd_license_attribution/config/string_formatting_config.py
+++ b/src/dd_license_attribution/config/string_formatting_config.py
@@ -1,0 +1,16 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+from dataclasses import dataclass
+
+
+@dataclass
+class StringFormattingConfig:
+    preset_company_suffixes: list[str]
+
+
+default_config = StringFormattingConfig(
+    preset_company_suffixes=["inc", "inc.", "llc", "llc."]
+)

--- a/src/dd_license_attribution/metadata_collector/strategies/cleanup_copyright_metadata_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/cleanup_copyright_metadata_strategy.py
@@ -20,7 +20,7 @@ class CleanupCopyrightMetadataStrategy(MetadataCollectionStrategy):
 
         """
         return re.sub(
-            r"copyright|\(c\)|\b\d{4}(?:\s?-\s?(?:\d{4}|present))?\b",
+            r"copyright(?:ed)?|\(c\)|\b\d{4}(?:\s?-\s?(?:\d{4}|present))?\b",
             "",
             copyright_text,
             flags=re.IGNORECASE,

--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -61,7 +61,7 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
         return []
 
     def _extract_copyright_from_pkg_data(self, pkg_data: Dict[str, Any]) -> List[str]:
-        if "author" not in pkg_data or not pkg_data["author"]:
+        if not pkg_data.get("author"):
             return []
 
         author = pkg_data["author"]

--- a/src/dd_license_attribution/utils/custom_splitting.py
+++ b/src/dd_license_attribution/utils/custom_splitting.py
@@ -1,0 +1,27 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+
+class CustomSplit:
+    def __init__(self, protected_terms: list[str]):
+        self.protected_terms = protected_terms
+
+    def custom_split(self, text: str, delimiter: str) -> list[str]:
+        parts = text.split(delimiter)
+        result = [parts[0].strip()]
+        for string in parts[1:]:
+            string = string.strip()
+            if self._should_split(string):
+                result.append(string)
+            else:
+                result[-1] += f"{delimiter} {string}"
+        return result
+
+    def _should_split(self, text: str) -> bool:
+        return not any(
+            text.lower().startswith(string) for string in self.protected_terms
+        )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x ] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This is a draft PR, to get comments before I finish it off.
Currently, the new util is being used in 1 collection strategy.

## Related tickets & Documents

https://datadoghq.atlassian.net/browse/OSPO-251
