### PR TITLE
Add a new collection strategy that reads a LICENSE-3rdparty file

### DIFF
--- a/src/dd_license_attribution/metadata_collector/strategies/license_3rdparty_metadata_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/license_3rdparty_metadata_collection_strategy.py
@@ -1,0 +1,93 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+import ast
+import csv
+
+from dd_license_attribution.metadata_collector.metadata import Metadata
+from dd_license_attribution.metadata_collector.strategies.abstract_collection_strategy import (  # noqa: E501
+    MetadataCollectionStrategy,
+)
+
+
+class License3rdPartyMetadataCollectionStrategy(MetadataCollectionStrategy):
+    """
+    A metadata collection strategy that reads LICENSE-3rdparty.csv files
+    and converts them to Metadata objects.
+    """
+
+    def __init__(self, csv_file_path: str):
+        self.csv_file_path = csv_file_path
+
+    def augment_metadata(self, metadata: list[Metadata]) -> list[Metadata]:
+        with open(self.csv_file_path, "r", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        if not rows:
+            return metadata
+
+        # Create a case-insensitive mapping of column names to actual
+        # column names. This allows CSV files with columns like
+        # "Component", "LICENSE", etc. to work
+        column_mapping = {col.lower(): col for col in rows[0].keys()}
+
+        required_columns = {"component", "origin", "license", "copyright"}
+        missing_columns = required_columns - column_mapping.keys()
+
+        if missing_columns:
+            columns_str = ", ".join(required_columns)
+            raise ValueError(f"CSV file must contain columns: {columns_str}")
+
+        # Get the actual column names from the mapping
+        license_col = column_mapping["license"]
+        copyright_col = column_mapping["copyright"]
+        component_col = column_mapping["component"]
+        origin_col = column_mapping["origin"]
+
+        updated_metadata = metadata.copy()
+        for row in rows:
+            # Parse the license and copyright fields
+            # (they are string representations of lists)
+            try:
+                license_list = (
+                    ast.literal_eval(row[license_col]) if row[license_col] else []
+                )
+                copyright_list = (
+                    ast.literal_eval(row[copyright_col]) if row[copyright_col] else []
+                )
+            except (ValueError, SyntaxError):
+                # If parsing fails, treat as empty
+                license_list = []
+                copyright_list = []
+
+            # Check if metadata with this name already exists to augment existing metadata
+            existing = next(
+                (m for m in metadata if m.name == row[component_col]),
+                None,
+            )
+
+            if existing is not None:
+                # Merge with existing metadata, keeping existing
+                # non-empty values
+                if not existing.origin:
+                    existing.origin = row[origin_col]
+                if not existing.license:
+                    existing.license = license_list
+                if not existing.copyright:
+                    existing.copyright = copyright_list
+            else:
+                # Create new Metadata object
+                meta = Metadata(
+                    name=row[component_col],
+                    origin=row[origin_col],
+                    local_src_path=None,
+                    version=None,
+                    license=license_list,
+                    copyright=copyright_list,
+                )
+                updated_metadata.append(meta)
+
+        return updated_metadata

--- a/tests/unit/test_license_3rdparty_collection_strategy.py
+++ b/tests/unit/test_license_3rdparty_collection_strategy.py
@@ -1,0 +1,300 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from dd_license_attribution.metadata_collector.metadata import Metadata
+from dd_license_attribution.metadata_collector.strategies.license_3rdparty_metadata_collection_strategy import (  # noqa: E501
+    License3rdPartyMetadataCollectionStrategy,
+)
+
+
+def test_reads_valid_csv_file() -> None:
+    """Test reading a valid LICENSE-3rdparty.csv file."""
+    csv_content = """component,origin,license,copyright
+test-package,https://github.com/test/package,"['MIT']","['Test Author']"
+another-package,https://github.com/another/package,"['Apache-2.0']","['Another Author', 'Co-Author']"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+        result = strategy.augment_metadata([])
+
+        assert len(result) == 2
+        assert result[0].name == "test-package"
+        assert result[0].origin == "https://github.com/test/package"
+        assert result[0].license == ["MIT"]
+        assert result[0].copyright == ["Test Author"]
+        assert result[0].version is None
+        assert result[0].local_src_path is None
+
+        assert result[1].name == "another-package"
+        assert result[1].origin == "https://github.com/another/package"
+        assert result[1].license == ["Apache-2.0"]
+        assert result[1].copyright == ["Another Author", "Co-Author"]
+        assert result[1].version is None
+        assert result[1].local_src_path is None
+
+        Path(tmp_file.name).unlink()
+
+
+def test_handles_case_insensitive_column_names() -> None:
+    """Test that column names are case-insensitive."""
+    csv_content = """Component,Origin,LICENSE,COPYRIGHT
+test-package,https://github.com/test/package,"['MIT']","['Test Author']"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+        result = strategy.augment_metadata([])
+
+        assert len(result) == 1
+        assert result[0].name == "test-package"
+        assert result[0].origin == "https://github.com/test/package"
+        assert result[0].license == ["MIT"]
+        assert result[0].copyright == ["Test Author"]
+        assert result[0].version is None
+        assert result[0].local_src_path is None
+
+        Path(tmp_file.name).unlink()
+
+
+def test_handles_empty_csv_file() -> None:
+    """Test handling of an empty CSV file."""
+    csv_content = """component,origin,license,copyright
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+        result = strategy.augment_metadata([])
+
+        assert len(result) == 0
+
+        Path(tmp_file.name).unlink()
+
+
+def test_raises_error_on_missing_required_columns() -> None:
+    """Test that missing required columns raises ValueError."""
+    csv_content = """component,origin,license
+test-package,https://github.com/test/package,"['MIT']"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+
+        with pytest.raises(ValueError, match="CSV file must contain columns"):
+            strategy.augment_metadata([])
+
+        Path(tmp_file.name).unlink()
+
+
+def test_handles_empty_license_and_copyright_fields() -> None:
+    """Test handling of empty license and copyright fields."""
+    csv_content = """component,origin,license,copyright
+test-package,https://github.com/test/package,,
+another-package,https://github.com/another/package,"[]","[]"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+        result = strategy.augment_metadata([])
+
+        assert len(result) == 2
+        assert result[0].name == "test-package"
+        assert result[0].origin == "https://github.com/test/package"
+        assert result[0].license == []
+        assert result[0].copyright == []
+        assert result[0].version is None
+        assert result[0].local_src_path is None
+
+        assert result[1].name == "another-package"
+        assert result[1].origin == "https://github.com/another/package"
+        assert result[1].license == []
+        assert result[1].copyright == []
+        assert result[1].version is None
+        assert result[1].local_src_path is None
+
+        Path(tmp_file.name).unlink()
+
+
+def test_handles_malformed_license_copyright_as_empty() -> None:
+    """Test that malformed license/copyright strings are treated as empty."""
+    csv_content = """component,origin,license,copyright
+test-package,https://github.com/test/package,"invalid-list","not-a-list"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+        result = strategy.augment_metadata([])
+
+        assert len(result) == 1
+        assert result[0].name == "test-package"
+        assert result[0].origin == "https://github.com/test/package"
+        assert result[0].license == []
+        assert result[0].copyright == []
+        assert result[0].version is None
+        assert result[0].local_src_path is None
+
+        Path(tmp_file.name).unlink()
+
+
+def test_augments_existing_metadata_list() -> None:
+    """Test that the strategy augments rather than replaces metadata."""
+    csv_content = """component,origin,license,copyright
+csv-package,https://github.com/csv/package,"['MIT']","['CSV Author']"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        existing_metadata = [
+            Metadata(
+                name="existing-package",
+                origin="https://github.com/existing/package",
+                version="1.0.0",
+                local_src_path="/path/to/package",
+                license=["Apache-2.0"],
+                copyright=["Existing Author"],
+            )
+        ]
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+        result = strategy.augment_metadata(existing_metadata)
+
+        assert len(result) == 2
+        assert result[0].name == "existing-package"
+        assert result[0].origin == "https://github.com/existing/package"
+        assert result[0].version == "1.0.0"
+        assert result[0].local_src_path == "/path/to/package"
+        assert result[0].license == ["Apache-2.0"]
+        assert result[0].copyright == ["Existing Author"]
+        assert result[1].name == "csv-package"
+        assert result[1].origin == "https://github.com/csv/package"
+        assert result[1].version is None
+        assert result[1].local_src_path is None
+        assert result[1].license == ["MIT"]
+        assert result[1].copyright == ["CSV Author"]
+
+        Path(tmp_file.name).unlink()
+
+
+def test_merges_with_existing_metadata_by_name() -> None:
+    """Test that existing metadata values are preserved when merging."""
+    csv_content = """component,origin,license,copyright
+existing-package,https://github.com/csv/package,"['MIT']","['CSV Author']"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        # Existing metadata with same name but different values
+        existing_metadata = [
+            Metadata(
+                name="existing-package",
+                origin="https://github.com/existing/package",
+                version="1.0.0",
+                local_src_path="/path/to/package",
+                license=["Apache-2.0"],
+                copyright=["Existing Author"],
+            )
+        ]
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+        result = strategy.augment_metadata(existing_metadata)
+
+        # Should only have 1 entry (merged, not added)
+        assert len(result) == 1
+        # Existing non-empty values should be preserved
+        assert result[0].name == "existing-package"
+        assert result[0].origin == "https://github.com/existing/package"
+        assert result[0].version == "1.0.0"
+        assert result[0].local_src_path == "/path/to/package"
+        assert result[0].license == ["Apache-2.0"]
+        assert result[0].copyright == ["Existing Author"]
+
+        Path(tmp_file.name).unlink()
+
+
+def test_fills_empty_fields_in_existing_metadata() -> None:
+    """Test that empty fields in existing metadata are filled from CSV."""
+    csv_content = """component,origin,license,copyright
+existing-package,https://github.com/csv/package,"['MIT']","['CSV Author']"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        # Existing metadata with empty license and copyright
+        existing_metadata = [
+            Metadata(
+                name="existing-package",
+                origin="https://github.com/existing/package",
+                version="1.0.0",
+                local_src_path="/path/to/package",
+                license=[],
+                copyright=[],
+            )
+        ]
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+        result = strategy.augment_metadata(existing_metadata)
+
+        # Should only have 1 entry (merged, not added)
+        assert len(result) == 1
+        # Empty values should be filled from CSV
+        assert result[0].name == "existing-package"
+        assert result[0].origin == "https://github.com/existing/package"
+        assert result[0].license == ["MIT"]
+        assert result[0].copyright == ["CSV Author"]
+        assert result[0].version == "1.0.0"
+        assert result[0].local_src_path == "/path/to/package"
+
+        Path(tmp_file.name).unlink()
+
+
+def test_raises_file_not_found_error() -> None:
+    """Test that FileNotFoundError is raised for non-existent file."""
+    strategy = License3rdPartyMetadataCollectionStrategy("/nonexistent/file.csv")
+
+    with pytest.raises(FileNotFoundError):
+        strategy.augment_metadata([])
+
+
+def test_handles_mixed_case_column_names() -> None:
+    """Test various mixed case combinations for column names."""
+    csv_content = """CoMpOnEnT,ORIGIN,LiCeNsE,CoPyRiGhT
+test-package,https://github.com/test/package,"['MIT']","['Test Author']"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_file.write(csv_content)
+        tmp_file.flush()
+
+        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+        result = strategy.augment_metadata([])
+
+        assert len(result) == 1
+        assert result[0].name == "test-package"
+        assert result[0].origin == "https://github.com/test/package"
+        assert result[0].license == ["MIT"]
+        assert result[0].copyright == ["Test Author"]
+        assert result[0].version is None
+        assert result[0].local_src_path is None
+
+        Path(tmp_file.name).unlink()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This is another step to create the new command to generate the overrides file. 

To follow the same patterns, to read the `LICENSE-3rdparty.csv` file, I have created a new collection strategy, that augments the metadata list using existing data in one of these files.

Right now this new strategy is not used anywhere (I will be using it in follow up PRs).

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
