### PR TITLE
Fix License 3rdparty collection strategy not returning a proper error when the CSV is invalid

### DIFF
--- a/src/dd_license_attribution/metadata_collector/strategies/license_3rdparty_metadata_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/license_3rdparty_metadata_collection_strategy.py
@@ -25,10 +25,11 @@ class License3rdPartyMetadataCollectionStrategy(MetadataCollectionStrategy):
         with open(self.csv_file_path, "r", encoding="utf-8") as f:
             reader = csv.DictReader(f)
             rows = list(reader)
-
         if not rows:
             return metadata
 
+        if None in rows[0].keys():
+            raise ValueError("Invalid CSV format")
         # Create a case-insensitive mapping of column names to actual
         # column names. This allows CSV files with columns like
         # "Component", "LICENSE", etc. to work

--- a/tests/unit/test_license_3rdparty_collection_strategy.py
+++ b/tests/unit/test_license_3rdparty_collection_strategy.py
@@ -3,7 +3,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2025-present Datadog, Inc.
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -14,259 +13,232 @@ from dd_license_attribution.metadata_collector.strategies.license_3rdparty_metad
 )
 
 
-def test_reads_valid_csv_file() -> None:
+def test_reads_valid_csv_file(tmp_path: Path) -> None:
     """Test reading a valid LICENSE-3rdparty.csv file."""
     csv_content = """component,origin,license,copyright
 test-package,https://github.com/test/package,"['MIT']","['Test Author']"
 another-package,https://github.com/another/package,"['Apache-2.0']","['Another Author', 'Co-Author']"
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
-        result = strategy.augment_metadata([])
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+    result = strategy.augment_metadata([])
 
-        assert len(result) == 2
-        assert result[0].name == "test-package"
-        assert result[0].origin == "https://github.com/test/package"
-        assert result[0].license == ["MIT"]
-        assert result[0].copyright == ["Test Author"]
-        assert result[0].version is None
-        assert result[0].local_src_path is None
+    assert len(result) == 2
+    assert result[0].name == "test-package"
+    assert result[0].origin == "https://github.com/test/package"
+    assert result[0].license == ["MIT"]
+    assert result[0].copyright == ["Test Author"]
+    assert result[0].version is None
+    assert result[0].local_src_path is None
 
-        assert result[1].name == "another-package"
-        assert result[1].origin == "https://github.com/another/package"
-        assert result[1].license == ["Apache-2.0"]
-        assert result[1].copyright == ["Another Author", "Co-Author"]
-        assert result[1].version is None
-        assert result[1].local_src_path is None
-
-        Path(tmp_file.name).unlink()
+    assert result[1].name == "another-package"
+    assert result[1].origin == "https://github.com/another/package"
+    assert result[1].license == ["Apache-2.0"]
+    assert result[1].copyright == ["Another Author", "Co-Author"]
+    assert result[1].version is None
+    assert result[1].local_src_path is None
 
 
-def test_handles_case_insensitive_column_names() -> None:
+def test_handles_case_insensitive_column_names(tmp_path: Path) -> None:
     """Test that column names are case-insensitive."""
     csv_content = """Component,Origin,LICENSE,COPYRIGHT
 test-package,https://github.com/test/package,"['MIT']","['Test Author']"
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
-        result = strategy.augment_metadata([])
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+    result = strategy.augment_metadata([])
 
-        assert len(result) == 1
-        assert result[0].name == "test-package"
-        assert result[0].origin == "https://github.com/test/package"
-        assert result[0].license == ["MIT"]
-        assert result[0].copyright == ["Test Author"]
-        assert result[0].version is None
-        assert result[0].local_src_path is None
-
-        Path(tmp_file.name).unlink()
+    assert len(result) == 1
+    assert result[0].name == "test-package"
+    assert result[0].origin == "https://github.com/test/package"
+    assert result[0].license == ["MIT"]
+    assert result[0].copyright == ["Test Author"]
+    assert result[0].version is None
+    assert result[0].local_src_path is None
 
 
-def test_handles_empty_csv_file() -> None:
+def test_handles_empty_csv_file(tmp_path: Path) -> None:
     """Test handling of an empty CSV file."""
     csv_content = """component,origin,license,copyright
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
-        result = strategy.augment_metadata([])
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+    result = strategy.augment_metadata([])
 
-        assert len(result) == 0
-
-        Path(tmp_file.name).unlink()
+    assert len(result) == 0
 
 
-def test_raises_error_on_missing_required_columns() -> None:
+def test_raises_error_on_missing_required_columns(tmp_path: Path) -> None:
     """Test that missing required columns raises ValueError."""
     csv_content = """component,origin,license
 test-package,https://github.com/test/package,"['MIT']"
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
 
-        with pytest.raises(ValueError, match="CSV file must contain columns"):
-            strategy.augment_metadata([])
-
-        Path(tmp_file.name).unlink()
+    with pytest.raises(ValueError, match="CSV file must contain columns"):
+        strategy.augment_metadata([])
 
 
-def test_handles_empty_license_and_copyright_fields() -> None:
+def test_handles_empty_license_and_copyright_fields(tmp_path: Path) -> None:
     """Test handling of empty license and copyright fields."""
     csv_content = """component,origin,license,copyright
 test-package,https://github.com/test/package,,
 another-package,https://github.com/another/package,"[]","[]"
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
-        result = strategy.augment_metadata([])
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+    result = strategy.augment_metadata([])
 
-        assert len(result) == 2
-        assert result[0].name == "test-package"
-        assert result[0].origin == "https://github.com/test/package"
-        assert result[0].license == []
-        assert result[0].copyright == []
-        assert result[0].version is None
-        assert result[0].local_src_path is None
+    assert len(result) == 2
+    assert result[0].name == "test-package"
+    assert result[0].origin == "https://github.com/test/package"
+    assert result[0].license == []
+    assert result[0].copyright == []
+    assert result[0].version is None
+    assert result[0].local_src_path is None
 
-        assert result[1].name == "another-package"
-        assert result[1].origin == "https://github.com/another/package"
-        assert result[1].license == []
-        assert result[1].copyright == []
-        assert result[1].version is None
-        assert result[1].local_src_path is None
-
-        Path(tmp_file.name).unlink()
+    assert result[1].name == "another-package"
+    assert result[1].origin == "https://github.com/another/package"
+    assert result[1].license == []
+    assert result[1].copyright == []
+    assert result[1].version is None
+    assert result[1].local_src_path is None
 
 
-def test_handles_malformed_license_copyright_as_empty() -> None:
+def test_handles_malformed_license_copyright_as_empty(tmp_path: Path) -> None:
     """Test that malformed license/copyright strings are treated as empty."""
     csv_content = """component,origin,license,copyright
 test-package,https://github.com/test/package,"invalid-list","not-a-list"
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
-        result = strategy.augment_metadata([])
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+    result = strategy.augment_metadata([])
 
-        assert len(result) == 1
-        assert result[0].name == "test-package"
-        assert result[0].origin == "https://github.com/test/package"
-        assert result[0].license == []
-        assert result[0].copyright == []
-        assert result[0].version is None
-        assert result[0].local_src_path is None
-
-        Path(tmp_file.name).unlink()
+    assert len(result) == 1
+    assert result[0].name == "test-package"
+    assert result[0].origin == "https://github.com/test/package"
+    assert result[0].license == []
+    assert result[0].copyright == []
+    assert result[0].version is None
+    assert result[0].local_src_path is None
 
 
-def test_augments_existing_metadata_list() -> None:
+def test_augments_existing_metadata_list(tmp_path: Path) -> None:
     """Test that the strategy augments rather than replaces metadata."""
     csv_content = """component,origin,license,copyright
 csv-package,https://github.com/csv/package,"['MIT']","['CSV Author']"
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        existing_metadata = [
-            Metadata(
-                name="existing-package",
-                origin="https://github.com/existing/package",
-                version="1.0.0",
-                local_src_path="/path/to/package",
-                license=["Apache-2.0"],
-                copyright=["Existing Author"],
-            )
-        ]
+    existing_metadata = [
+        Metadata(
+            name="existing-package",
+            origin="https://github.com/existing/package",
+            version="1.0.0",
+            local_src_path="/path/to/package",
+            license=["Apache-2.0"],
+            copyright=["Existing Author"],
+        )
+    ]
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
-        result = strategy.augment_metadata(existing_metadata)
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+    result = strategy.augment_metadata(existing_metadata)
 
-        assert len(result) == 2
-        assert result[0].name == "existing-package"
-        assert result[0].origin == "https://github.com/existing/package"
-        assert result[0].version == "1.0.0"
-        assert result[0].local_src_path == "/path/to/package"
-        assert result[0].license == ["Apache-2.0"]
-        assert result[0].copyright == ["Existing Author"]
-        assert result[1].name == "csv-package"
-        assert result[1].origin == "https://github.com/csv/package"
-        assert result[1].version is None
-        assert result[1].local_src_path is None
-        assert result[1].license == ["MIT"]
-        assert result[1].copyright == ["CSV Author"]
-
-        Path(tmp_file.name).unlink()
+    assert len(result) == 2
+    assert result[0].name == "existing-package"
+    assert result[0].origin == "https://github.com/existing/package"
+    assert result[0].version == "1.0.0"
+    assert result[0].local_src_path == "/path/to/package"
+    assert result[0].license == ["Apache-2.0"]
+    assert result[0].copyright == ["Existing Author"]
+    assert result[1].name == "csv-package"
+    assert result[1].origin == "https://github.com/csv/package"
+    assert result[1].version is None
+    assert result[1].local_src_path is None
+    assert result[1].license == ["MIT"]
+    assert result[1].copyright == ["CSV Author"]
 
 
-def test_merges_with_existing_metadata_by_name() -> None:
+def test_merges_with_existing_metadata_by_name(tmp_path: Path) -> None:
     """Test that existing metadata values are preserved when merging."""
     csv_content = """component,origin,license,copyright
 existing-package,https://github.com/csv/package,"['MIT']","['CSV Author']"
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        # Existing metadata with same name but different values
-        existing_metadata = [
-            Metadata(
-                name="existing-package",
-                origin="https://github.com/existing/package",
-                version="1.0.0",
-                local_src_path="/path/to/package",
-                license=["Apache-2.0"],
-                copyright=["Existing Author"],
-            )
-        ]
+    # Existing metadata with same name but different values
+    existing_metadata = [
+        Metadata(
+            name="existing-package",
+            origin="https://github.com/existing/package",
+            version="1.0.0",
+            local_src_path="/path/to/package",
+            license=["Apache-2.0"],
+            copyright=["Existing Author"],
+        )
+    ]
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
-        result = strategy.augment_metadata(existing_metadata)
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+    result = strategy.augment_metadata(existing_metadata)
 
-        # Should only have 1 entry (merged, not added)
-        assert len(result) == 1
-        # Existing non-empty values should be preserved
-        assert result[0].name == "existing-package"
-        assert result[0].origin == "https://github.com/existing/package"
-        assert result[0].version == "1.0.0"
-        assert result[0].local_src_path == "/path/to/package"
-        assert result[0].license == ["Apache-2.0"]
-        assert result[0].copyright == ["Existing Author"]
-
-        Path(tmp_file.name).unlink()
+    # Should only have 1 entry (merged, not added)
+    assert len(result) == 1
+    # Existing non-empty values should be preserved
+    assert result[0].name == "existing-package"
+    assert result[0].origin == "https://github.com/existing/package"
+    assert result[0].version == "1.0.0"
+    assert result[0].local_src_path == "/path/to/package"
+    assert result[0].license == ["Apache-2.0"]
+    assert result[0].copyright == ["Existing Author"]
 
 
-def test_fills_empty_fields_in_existing_metadata() -> None:
+def test_fills_empty_fields_in_existing_metadata(tmp_path: Path) -> None:
     """Test that empty fields in existing metadata are filled from CSV."""
     csv_content = """component,origin,license,copyright
 existing-package,https://github.com/csv/package,"['MIT']","['CSV Author']"
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        # Existing metadata with empty license and copyright
-        existing_metadata = [
-            Metadata(
-                name="existing-package",
-                origin="https://github.com/existing/package",
-                version="1.0.0",
-                local_src_path="/path/to/package",
-                license=[],
-                copyright=[],
-            )
-        ]
+    # Existing metadata with empty license and copyright
+    existing_metadata = [
+        Metadata(
+            name="existing-package",
+            origin="https://github.com/existing/package",
+            version="1.0.0",
+            local_src_path="/path/to/package",
+            license=[],
+            copyright=[],
+        )
+    ]
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
-        result = strategy.augment_metadata(existing_metadata)
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+    result = strategy.augment_metadata(existing_metadata)
 
-        # Should only have 1 entry (merged, not added)
-        assert len(result) == 1
-        # Empty values should be filled from CSV
-        assert result[0].name == "existing-package"
-        assert result[0].origin == "https://github.com/existing/package"
-        assert result[0].license == ["MIT"]
-        assert result[0].copyright == ["CSV Author"]
-        assert result[0].version == "1.0.0"
-        assert result[0].local_src_path == "/path/to/package"
-
-        Path(tmp_file.name).unlink()
+    # Should only have 1 entry (merged, not added)
+    assert len(result) == 1
+    # Empty values should be filled from CSV
+    assert result[0].name == "existing-package"
+    assert result[0].origin == "https://github.com/existing/package"
+    assert result[0].license == ["MIT"]
+    assert result[0].copyright == ["CSV Author"]
+    assert result[0].version == "1.0.0"
+    assert result[0].local_src_path == "/path/to/package"
 
 
 def test_raises_file_not_found_error() -> None:
@@ -277,24 +249,21 @@ def test_raises_file_not_found_error() -> None:
         strategy.augment_metadata([])
 
 
-def test_handles_mixed_case_column_names() -> None:
+def test_handles_mixed_case_column_names(tmp_path: Path) -> None:
     """Test various mixed case combinations for column names."""
     csv_content = """CoMpOnEnT,ORIGIN,LiCeNsE,CoPyRiGhT
 test-package,https://github.com/test/package,"['MIT']","['Test Author']"
 """
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
-        tmp_file.write(csv_content)
-        tmp_file.flush()
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
 
-        strategy = License3rdPartyMetadataCollectionStrategy(tmp_file.name)
-        result = strategy.augment_metadata([])
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+    result = strategy.augment_metadata([])
 
-        assert len(result) == 1
-        assert result[0].name == "test-package"
-        assert result[0].origin == "https://github.com/test/package"
-        assert result[0].license == ["MIT"]
-        assert result[0].copyright == ["Test Author"]
-        assert result[0].version is None
-        assert result[0].local_src_path is None
-
-        Path(tmp_file.name).unlink()
+    assert len(result) == 1
+    assert result[0].name == "test-package"
+    assert result[0].origin == "https://github.com/test/package"
+    assert result[0].license == ["MIT"]
+    assert result[0].copyright == ["Test Author"]
+    assert result[0].version is None
+    assert result[0].local_src_path is None

--- a/tests/unit/test_license_3rdparty_collection_strategy.py
+++ b/tests/unit/test_license_3rdparty_collection_strategy.py
@@ -267,3 +267,19 @@ test-package,https://github.com/test/package,"['MIT']","['Test Author']"
     assert result[0].copyright == ["Test Author"]
     assert result[0].version is None
     assert result[0].local_src_path is None
+
+
+def test_raises_error_on_invalid_csv_format_with_extra_columns(
+    tmp_path: Path,
+) -> None:
+    """Test that invalid CSV format with extra columns raises ValueError."""
+    csv_content = """component,origin,license,copyright
+test-package,https://github.com/test/package,"['MIT']","['Test Author']",extra
+"""
+    csv_file = tmp_path / "test.csv"
+    csv_file.write_text(csv_content)
+
+    strategy = License3rdPartyMetadataCollectionStrategy(str(csv_file))
+
+    with pytest.raises(ValueError, match="Invalid CSV format"):
+        strategy.augment_metadata([])


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

Fix a bug in the License3rdParty collection strategy when the CSV is incorrect. 
Added a test for it as well.

The first commit improves the tests temp file fixture. Review commit per commit should be easier.


