### PR TITLE
Add Yarn package manager support to npm collection strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Added
-- Support for GitHub renamed/transferred repositories.
+### Added
+- Support for GitHub renamed/transferred repositories
+- Support for Yarn package manager in npm collection
 
 ## [0.5.0] - 2025-10-29
 

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -43,6 +43,9 @@ def setup_npm_strategy_mocks(
     """Setup common mocks for npm collection strategy tests."""
 
     def fake_exists(path: str) -> bool:
+        # Return False for yarn.lock to ensure npm path is taken
+        if "yarn.lock" in path:
+            return False
         return True
 
     def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
@@ -230,9 +233,9 @@ def test_npm_collection_strategy_adds_npm_metadata(
     mock_output_from_command.assert_called_once_with(
         f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
     )
-    assert mock_exists.call_count == 2
-    assert mock_path_join.call_count == 2
-    assert mock_open.call_count == 2
+    assert mock_exists.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_path_join.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_open.call_count == 2  # package.json, package-lock.json
     assert mock_requests.call_count == 2
 
 
@@ -340,9 +343,9 @@ def test_npm_collection_strategy_extracts_transitive_dependencies(
     mock_output_from_command.assert_called_once_with(
         f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
     )
-    assert mock_exists.call_count == 2
-    assert mock_path_join.call_count == 2
-    assert mock_open.call_count == 2
+    assert mock_exists.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_path_join.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_open.call_count == 2  # package.json, package-lock.json
     assert mock_requests.call_count == 4
 
 
@@ -406,9 +409,9 @@ def test_npm_collection_strategy_avoids_duplicates_and_respects_only_transitive(
     mock_output_from_command.assert_called_once_with(
         f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
     )
-    assert mock_exists.call_count == 2
-    assert mock_path_join.call_count == 2
-    assert mock_open.call_count == 2
+    assert mock_exists.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_path_join.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_open.call_count == 2  # package.json, package-lock.json
     assert mock_requests.call_count == 1
 
 
@@ -451,9 +454,9 @@ def test_npm_collection_strategy_handles_missing_packages_key(
     mock_output_from_command.assert_called_once_with(
         f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
     )
-    assert mock_exists.call_count == 2
-    assert mock_path_join.call_count == 2
-    assert mock_open.call_count == 2
+    assert mock_exists.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_path_join.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_open.call_count == 2  # package.json, package-lock.json
     mock_requests.assert_not_called()
     assert result == initial_metadata
 
@@ -496,9 +499,9 @@ def test_npm_collection_strategy_handles_missing_root_package(
     mock_output_from_command.assert_called_once_with(
         f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
     )
-    assert mock_exists.call_count == 2
-    assert mock_path_join.call_count == 2
-    assert mock_open.call_count == 2
+    assert mock_exists.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_path_join.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_open.call_count == 2  # package.json, package-lock.json
     mock_requests.assert_not_called()
 
 
@@ -557,9 +560,9 @@ def test_npm_collection_strategy_handles_registry_api_failures(
     mock_output_from_command.assert_called_once_with(
         f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
     )
-    assert mock_exists.call_count == 2
-    assert mock_path_join.call_count == 2
-    assert mock_open.call_count == 2
+    assert mock_exists.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_path_join.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_open.call_count == 2  # package.json, package-lock.json
     assert mock_requests.call_count == 2
 
 
@@ -616,9 +619,9 @@ def test_npm_collection_strategy_logs_warning_on_non_200_response(
     mock_output_from_command.assert_called_once_with(
         f"CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
     )
-    assert mock_exists.call_count == 2
-    assert mock_path_join.call_count == 2
-    assert mock_open.call_count == 2
+    assert mock_exists.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_path_join.call_count == 3  # package.json, yarn.lock, package-lock.json
+    assert mock_open.call_count == 2  # package.json, package-lock.json
     assert mock_requests.call_count == 1
 
 
@@ -666,9 +669,9 @@ def test_npm_collection_strategy_handles_npm_install_failure(
     mock_output_from_command.assert_called_once_with(
         "CWD=`pwd`; cd cache_dir/org_package1 && npm install --package-lock-only --force; cd $CWD"
     )
-    mock_exists.assert_called_once()
-    mock_path_join.assert_called_once_with("cache_dir/org_package1", "package.json")
-    mock_open.assert_called_once()
+    assert mock_exists.call_count == 2  # package.json, yarn.lock
+    assert mock_path_join.call_count == 2  # package.json, yarn.lock
+    mock_open.assert_called_once()  # Only package.json
     mock_requests.assert_not_called()
 
 
@@ -853,19 +856,326 @@ def test_extract_copyright_from_pkg_data() -> None:
         ), f"Failed for '{test_input}': expected '{expected_output}', got '{result}'"
 
 
-def test_npm_collection_strategy_with_package_json_enrichment(
+# ============================================================================
+# Tests for Yarn support
+# ============================================================================
+
+
+def test_detect_package_manager_with_yarn_lock(
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """Test npm collection strategy enriches root package from package.json."""
+    """Test _detect_package_manager returns 'yarn' when yarn.lock exists."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    def fake_exists(path: str) -> bool:
+        return "yarn.lock" in path
+
+    def fake_path_join(*args: Any) -> str:
+        return "/".join(args)
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_exists",
+        side_effect=fake_exists,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_join",
+        side_effect=fake_path_join,
+    )
+
+    result = strategy._detect_package_manager("/project/path")
+    assert result == "yarn"
+
+
+def test_detect_package_manager_without_yarn_lock(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test _detect_package_manager returns 'npm' when yarn.lock doesn't exist."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    def fake_exists(path: str) -> bool:
+        return False
+
+    def fake_path_join(*args: Any) -> str:
+        return "/".join(args)
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_exists",
+        side_effect=fake_exists,
+    )
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.path_join",
+        side_effect=fake_path_join,
+    )
+
+    result = strategy._detect_package_manager("/project/path")
+    assert result == "npm"
+
+
+def test_extract_yarn_aliases_from_tree_with_aliases() -> None:
+    """Test _extract_yarn_aliases_from_tree extracts aliases correctly."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    trees: list[dict[str, Any]] = [
+        {
+            "name": "dep1@1.0.0",
+            "children": [
+                {"name": "string-width-cjs@npm:string-width@^4.2.0"},
+                {"name": "ansi-regex@^5.0.1"},
+            ],
+        },
+        {
+            "name": "dep2@2.0.0",
+            "children": [
+                {"name": "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0"},
+                {
+                    "name": "nested@1.0.0",
+                    "children": [
+                        {"name": "strip-ansi-cjs@npm:strip-ansi@^6.0.1"},
+                    ],
+                },
+            ],
+        },
+    ]
+
+    result = strategy._extract_yarn_aliases_from_tree(trees)
+    expected = {
+        "string-width-cjs": "string-width",
+        "wrap-ansi-cjs": "wrap-ansi",
+        "strip-ansi-cjs": "strip-ansi",
+    }
+    assert result == expected
+
+
+def test_extract_yarn_aliases_from_tree_no_aliases() -> None:
+    """Test _extract_yarn_aliases_from_tree with no aliases."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    trees = [
+        {
+            "name": "dep1@1.0.0",
+            "children": [
+                {"name": "ansi-regex@^5.0.1"},
+                {"name": "another-dep@^2.0.0"},
+            ],
+        },
+    ]
+
+    result = strategy._extract_yarn_aliases_from_tree(trees)
+    assert result == {}
+
+
+def test_extract_yarn_aliases_from_tree_empty_trees() -> None:
+    """Test _extract_yarn_aliases_from_tree with empty trees."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    result = strategy._extract_yarn_aliases_from_tree([])
+    assert result == {}
+
+
+def test_extract_yarn_aliases_from_tree_malformed_children() -> None:
+    """Test _extract_yarn_aliases_from_tree handles malformed children."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    trees = [
+        {
+            "name": "dep1@1.0.0",
+            "children": [
+                {"name": ""},  # Empty name
+                "not-a-dict",  # Not a dict
+                {"no-name-key": "value"},  # Missing name key
+            ],
+        },
+    ]
+
+    result = strategy._extract_yarn_aliases_from_tree(trees)
+    assert result == {}
+
+
+def test_get_yarn_dependencies_success(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test _get_yarn_dependencies successfully extracts dependencies."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    # Yarn output has multiple JSON objects on separate lines
+    yarn_output = """{"type":"tree","data":{"type":"list","trees":[{"name":"lodash@4.17.21","children":[]},{"name":"react@18.2.0","children":[{"name":"loose-envify@1.4.0"}]},{"name":"loose-envify@1.4.0","children":[]}]}}"""
+
+    mock_output_from_command = mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        return_value=yarn_output,
+    )
+
+    result = strategy._get_yarn_dependencies("/project/path")
+    expected = {
+        "lodash": "4.17.21",
+        "react": "18.2.0",
+        "loose-envify": "1.4.0",
+    }
+    assert result == expected
+
+    # Verify that the command includes --production flag to exclude dev dependencies
+    mock_output_from_command.assert_called_once()
+    called_command = mock_output_from_command.call_args[0][0]
+    assert "--production" in called_command
+    assert "yarn list" in called_command
+
+
+def test_get_yarn_dependencies_with_scoped_packages(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test _get_yarn_dependencies handles scoped packages."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    yarn_output = """{"type":"tree","data":{"type":"list","trees":[{"name":"@datadog/browser-core@5.0.0","children":[]},{"name":"@babel/runtime@7.22.0","children":[]}]}}"""
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        return_value=yarn_output,
+    )
+
+    result = strategy._get_yarn_dependencies("/project/path")
+    expected = {
+        "@datadog/browser-core": "5.0.0",
+        "@babel/runtime": "7.22.0",
+    }
+    assert result == expected
+
+
+def test_get_yarn_dependencies_with_aliases(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test _get_yarn_dependencies resolves aliases correctly."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    yarn_output = """{"type":"tree","data":{"type":"list","trees":[{"name":"string-width@4.2.3","children":[]},{"name":"string-width-cjs@4.2.3","children":[{"name":"string-width-cjs@npm:string-width@^4.2.0"}]}]}}"""
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        return_value=yarn_output,
+    )
+
+    result = strategy._get_yarn_dependencies("/project/path")
+    # The alias should be resolved to the real package name
+    assert "string-width" in result
+    assert result["string-width"] == "4.2.3"
+
+
+def test_get_yarn_dependencies_empty_output(
+    mocker: pytest_mock.MockFixture,
+    caplog: LogCaptureFixture,
+) -> None:
+    """Test _get_yarn_dependencies handles empty output."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        return_value="",
+    )
+
+    with caplog.at_level(logging.ERROR):
+        result = strategy._get_yarn_dependencies("/project/path")
+
+    assert result == {}
+    assert any(
+        "Yarn list produced no output" in record.message for record in caplog.records
+    )
+
+
+def test_get_yarn_dependencies_invalid_json(
+    mocker: pytest_mock.MockFixture,
+    caplog: LogCaptureFixture,
+) -> None:
+    """Test _get_yarn_dependencies handles invalid JSON output."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        return_value="not valid json\nanother line\n",
+    )
+
+    with caplog.at_level(logging.ERROR):
+        result = strategy._get_yarn_dependencies("/project/path")
+
+    assert result == {}
+    assert any(
+        "did not produce valid JSON output" in record.message
+        for record in caplog.records
+    )
+
+
+def test_get_yarn_dependencies_command_failure(
+    mocker: pytest_mock.MockFixture,
+    caplog: LogCaptureFixture,
+) -> None:
+    """Test _get_yarn_dependencies handles command failure."""
+    source_code_manager_mock = create_source_code_manager_mock()
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+
+    mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.output_from_command",
+        side_effect=Exception("Yarn command failed"),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = strategy._get_yarn_dependencies("/project/path")
+
+    assert result == {}
+    assert any("Failed to run yarn list" in record.message for record in caplog.records)
+
+
+def test_npm_collection_strategy_with_yarn_project(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test npm collection strategy handles Yarn projects."""
     source_code_manager_mock = create_source_code_manager_mock()
     package_json: dict[str, Any] = {"name": "test-package", "version": "1.0.0"}
-    package_lock: dict[str, Any] = {
-        "packages": {
-            "": {"dependencies": {"lodash": "4.17.21", "react": "18.2.0"}},
-            "node_modules/lodash": {"version": "4.17.21", "dependencies": {}},
-            "node_modules/react": {"version": "18.2.0", "dependencies": {}},
-        }
-    }
+
+    yarn_output = """{"type":"tree","data":{"type":"list","trees":[{"name":"lodash@4.17.21","children":[]},{"name":"react@18.2.0","children":[]}]}}"""
 
     requests_responses: list[mock.Mock] = [
         mock.Mock(status_code=200, json=lambda: {"license": "MIT", "author": "John"}),
@@ -878,15 +1188,17 @@ def test_npm_collection_strategy_with_package_json_enrichment(
     def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
         if "package.json" in path:
             return json.dumps(package_json)
-        elif "package-lock.json" in path:
-            return json.dumps(package_lock)
         raise FileNotFoundError
 
     def fake_path_join(*args: Any) -> str:
         return "/".join(args)
 
     def fake_output_from_command(command: str) -> str:
-        return "npm install completed"
+        if "yarn --version" in command:
+            return "1.22.19"
+        elif "yarn list" in command:
+            return yarn_output
+        return ""
 
     mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
@@ -903,7 +1215,7 @@ def test_npm_collection_strategy_with_package_json_enrichment(
         "npm_collection_strategy.open_file",
         side_effect=fake_open,
     )
-    mocker.patch(
+    mock_output_from_command = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
         "npm_collection_strategy.output_from_command",
         side_effect=fake_output_from_command,
@@ -928,9 +1240,8 @@ def test_npm_collection_strategy_with_package_json_enrichment(
     # Should have root package + 2 dependencies
     assert len(result) == 3
 
-    # Check root package metadata was enriched from package.json
-    assert result[0].name == "test-package"  # Enriched from package.json
-    assert result[0].version == "1.0.0"  # Enriched from package.json
+    # Check root package metadata remains unchanged
+    assert result[0].name == "package1"
     assert result[0].origin == "https://github.com/org/package1"
 
     # Check dependencies were added
@@ -938,12 +1249,28 @@ def test_npm_collection_strategy_with_package_json_enrichment(
     assert "lodash" in dep_names
     assert "react" in dep_names
 
+    # Verify that the yarn list command includes --production flag
+    yarn_list_calls = [
+        call
+        for call in mock_output_from_command.call_args_list
+        if "yarn list" in str(call)
+    ]
+    assert len(yarn_list_calls) > 0
+    yarn_command = str(yarn_list_calls[0])
+    assert "--production" in yarn_command
 
-def test_npm_collection_strategy_npm_install_failure(
+    # Verify yarn list was called, not npm install
+    yarn_list_called = any(
+        "yarn list" in str(call) for call in mock_output_from_command.call_args_list
+    )
+    assert yarn_list_called
+
+
+def test_npm_collection_strategy_yarn_not_installed(
     mocker: pytest_mock.MockFixture,
     caplog: LogCaptureFixture,
 ) -> None:
-    """Test npm collection strategy handles npm install failure but still enriches root package."""
+    """Test npm collection strategy handles yarn not being installed."""
     source_code_manager_mock = create_source_code_manager_mock()
     package_json: dict[str, Any] = {"name": "test-package", "version": "1.0.0"}
 
@@ -959,8 +1286,9 @@ def test_npm_collection_strategy_npm_install_failure(
         return "/".join(args)
 
     def fake_output_from_command(command: str) -> str:
-        # Simulate npm install failure
-        raise Exception("npm install failed")
+        if "yarn --version" in command:
+            raise Exception("yarn: command not found")
+        return ""
 
     mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
@@ -997,277 +1325,10 @@ def test_npm_collection_strategy_npm_install_failure(
         ),
     ]
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         result = strategy.augment_metadata(initial_metadata)
 
-    # Should return metadata with root package enriched from package.json
-    # but no dependencies since npm install failed
+    # Should return original metadata (no dependencies, root unchanged)
     assert len(result) == 1
-    assert (
-        result[0].name == "test-package"
-    )  # Enriched from package.json even when npm install fails
-    assert result[0].version == "1.0.0"  # Enriched from package.json
-    assert any(
-        "Failed to run npm install" in record.message for record in caplog.records
-    )
-
-
-# ============================================================================
-# Tests for root package enrichment from package.json
-# ============================================================================
-
-
-def test_enrich_root_package_from_package_json_with_license_and_copyright(
-    mocker: pytest_mock.MockFixture,
-) -> None:
-    """Test that root package metadata is enriched from package.json."""
-    source_code_manager_mock = create_source_code_manager_mock()
-    package_json: dict[str, Any] = {
-        "name": "test-package",
-        "version": "1.0.0",
-        "license": "Apache-2.0",
-        "author": "Test Author",
-    }
-
-    def fake_exists(path: str) -> bool:
-        return "package.json" in path
-
-    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
-        if "package.json" in path:
-            return json.dumps(package_json)
-        raise FileNotFoundError
-
-    def fake_path_join(*args: Any) -> str:
-        return "/".join(args)
-
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.path_exists",
-        side_effect=fake_exists,
-    )
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.path_join",
-        side_effect=fake_path_join,
-    )
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.open_file",
-        side_effect=fake_open,
-    )
-
-    strategy = NpmMetadataCollectionStrategy(
-        "https://github.com/org/test-package",
-        source_code_manager_mock,
-        ProjectScope.ONLY_ROOT_PROJECT,
-    )
-    initial_metadata = [
-        Metadata(
-            name="github.com/org/test-package",
-            origin="https://github.com/org/test-package",
-            local_src_path=None,
-            license=[],
-            version=None,
-            copyright=[],
-        ),
-    ]
-    result = strategy.augment_metadata(initial_metadata)
-
-    # Verify root package was enriched
-    assert len(result) == 1
-    assert result[0].name == "test-package"
-    assert result[0].version == "1.0.0"
-    assert result[0].license == ["Apache-2.0"]
-    assert result[0].copyright == ["Test Author"]
-    assert result[0].origin == "https://github.com/org/test-package"
-
-
-def test_enrich_root_package_from_package_json_with_dict_author(
-    mocker: pytest_mock.MockFixture,
-) -> None:
-    """Test that root package handles author as dict."""
-    source_code_manager_mock = create_source_code_manager_mock()
-    package_json: dict[str, Any] = {
-        "name": "test-package",
-        "version": "2.0.0",
-        "license": "MIT",
-        "author": {"name": "Jane Doe", "email": "jane@example.com"},
-    }
-
-    def fake_exists(path: str) -> bool:
-        return "package.json" in path
-
-    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
-        if "package.json" in path:
-            return json.dumps(package_json)
-        raise FileNotFoundError
-
-    def fake_path_join(*args: Any) -> str:
-        return "/".join(args)
-
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.path_exists",
-        side_effect=fake_exists,
-    )
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.path_join",
-        side_effect=fake_path_join,
-    )
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.open_file",
-        side_effect=fake_open,
-    )
-
-    strategy = NpmMetadataCollectionStrategy(
-        "https://github.com/org/test-package",
-        source_code_manager_mock,
-        ProjectScope.ONLY_ROOT_PROJECT,
-    )
-    initial_metadata = [
-        Metadata(
-            name="github.com/org/test-package",
-            origin="https://github.com/org/test-package",
-            local_src_path=None,
-            license=[],
-            version=None,
-            copyright=[],
-        ),
-    ]
-    result = strategy.augment_metadata(initial_metadata)
-
-    # Verify root package was enriched with author name
-    assert len(result) == 1
-    assert result[0].name == "test-package"
-    assert result[0].version == "2.0.0"
-    assert result[0].license == ["MIT"]
-    assert result[0].copyright == ["Jane Doe"]
-
-
-def test_enrich_root_package_from_package_json_missing_fields(
-    mocker: pytest_mock.MockFixture,
-) -> None:
-    """Test that root package handles missing license/author gracefully."""
-    source_code_manager_mock = create_source_code_manager_mock()
-    package_json: dict[str, Any] = {
-        "name": "test-package",
-        "version": "1.0.0",
-        # No license or author
-    }
-
-    def fake_exists(path: str) -> bool:
-        return "package.json" in path
-
-    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
-        if "package.json" in path:
-            return json.dumps(package_json)
-        raise FileNotFoundError
-
-    def fake_path_join(*args: Any) -> str:
-        return "/".join(args)
-
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.path_exists",
-        side_effect=fake_exists,
-    )
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.path_join",
-        side_effect=fake_path_join,
-    )
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.open_file",
-        side_effect=fake_open,
-    )
-
-    strategy = NpmMetadataCollectionStrategy(
-        "https://github.com/org/test-package",
-        source_code_manager_mock,
-        ProjectScope.ONLY_ROOT_PROJECT,
-    )
-    initial_metadata = [
-        Metadata(
-            name="github.com/org/test-package",
-            origin="https://github.com/org/test-package",
-            local_src_path=None,
-            license=[],
-            version=None,
-            copyright=[],
-        ),
-    ]
-    result = strategy.augment_metadata(initial_metadata)
-
-    # Verify root package was enriched with available fields only
-    assert len(result) == 1
-    assert result[0].name == "test-package"
-    assert result[0].version == "1.0.0"
-    assert result[0].license == []  # Not updated (empty)
-    assert result[0].copyright == []  # Not updated (empty)
-
-
-def test_enrich_root_package_overwrites_existing_data(
-    mocker: pytest_mock.MockFixture,
-) -> None:
-    """Test that root package enrichment overwrites existing data."""
-    source_code_manager_mock = create_source_code_manager_mock()
-    package_json: dict[str, Any] = {
-        "name": "correct-package-name",
-        "version": "2.0.0",
-        "license": "Apache-2.0",
-        "author": "Correct Author",
-    }
-
-    def fake_exists(path: str) -> bool:
-        return "package.json" in path
-
-    def fake_open(path: str, *args: Any, **kwargs: Any) -> Any:
-        if "package.json" in path:
-            return json.dumps(package_json)
-        raise FileNotFoundError
-
-    def fake_path_join(*args: Any) -> str:
-        return "/".join(args)
-
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.path_exists",
-        side_effect=fake_exists,
-    )
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.path_join",
-        side_effect=fake_path_join,
-    )
-    mocker.patch(
-        "dd_license_attribution.metadata_collector.strategies."
-        "npm_collection_strategy.open_file",
-        side_effect=fake_open,
-    )
-
-    strategy = NpmMetadataCollectionStrategy(
-        "https://github.com/org/test-package",
-        source_code_manager_mock,
-        ProjectScope.ONLY_ROOT_PROJECT,
-    )
-    initial_metadata = [
-        Metadata(
-            name="wrong-name",
-            origin="https://github.com/org/test-package",
-            local_src_path=None,
-            license=["Wrong License"],
-            version="1.0.0",
-            copyright=["Wrong Author"],
-        ),
-    ]
-    result = strategy.augment_metadata(initial_metadata)
-
-    # Verify root package was overwritten with package.json data
-    assert len(result) == 1
-    assert result[0].name == "correct-package-name"
-    assert result[0].version == "2.0.0"
-    assert result[0].license == ["Apache-2.0"]
-    assert result[0].copyright == ["Correct Author"]
+    assert result[0].name == "package1"
+    assert any("Yarn is not installed" in record.message for record in caplog.records)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This allows the npm collection strategy to work with both npm and Yarn projects, automatically detecting which package manager is in use and using the appropriate method to extract dependency information.

## Related tickets & Documents

None

## How to reproduce and testing

This should now work on the `dd-trace-js` repo:

```
dd-license-attribution --no-scancode-strategy --no-github-sbom-strategy https://github.com/datadog/dd-trace-js
```
