### PR TITLE
[OSPO-440] Add new command to generate a valid ddla-overrides file

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,13 +42,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          dd-license-attribution --only-root-project https://github.com/DataDog/stratus-red-team
+          dd-license-attribution generate-sbom-csv --only-root-project https://github.com/DataDog/stratus-red-team
 
-      - name: Run the dd-license-attribution script against the dd-trace-py repository with dependencies
+      - name: Run the dd-license-attribution script against the dd-license-attribution repository with overrides
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          dd-license-attribution --override-spec=.ddla-overrides https://github.com/DataDog/dd-license-attribution > ddla-output.txt
+          dd-license-attribution generate-sbom-csv --override-spec=.ddla-overrides https://github.com/DataDog/dd-license-attribution > ddla-output.txt
           if ! cmp -s LICENSE-3rdparty.csv ddla-output.txt; then
             echo "Error: LICENSE-3rdparty.csv differs from ddla-output.txt"
             echo "Diff between files:"

--- a/README.md
+++ b/README.md
@@ -30,10 +30,19 @@ pip install .
 ```
 4. Run the tool on a GitHub repository:
 ```bash
-dd-license-attribution https://github.com/owner/repo > LICENSE-3rdparty.csv
+dd-license-attribution generate-sbom-csv https://github.com/owner/repo > LICENSE-3rdparty.csv
 ```
 
 For more advanced usage, see the sections below.
+
+### Available Commands
+
+`dd-license-attribution` provides two main commands:
+
+1. **`generate-sbom-csv`** - Generate a CSV report (SBOM) of third-party dependencies
+2. **`generate-overrides`** - Interactively generate override configuration files
+
+Run `dd-license-attribution --help` to see all available commands.
 
 ### Requirements
 
@@ -50,6 +59,8 @@ For more advanced usage, see the sections below.
 
 ### Usage
 
+#### Generating SBOM Reports
+
 To install and run the command after cloning the repository:
 
 ```bash
@@ -58,10 +69,10 @@ pip install .
 
 # Optionally you can define a GITHUB_TOKEN, if used it will raise the throttling threashold and maspeed up your generation calls to github APIs.
 export GITHUB_TOKEN=YOUR_TOKEN
-dd-license-attribution https://github.com/owner/repo > LICENSE-3rdparty.csv
+dd-license-attribution generate-sbom-csv https://github.com/owner/repo > LICENSE-3rdparty.csv
 ```
 
-The following optional parameters are available:
+The following optional parameters are available for `generate-sbom-csv`:
 
 #### Scanning Options
 
@@ -101,7 +112,7 @@ requests,https://github.com/psf/requests,Apache-2.0,"Kenneth Reitz"
 
 #### Output string configuration
 
-There's a file at `src/dd_license_attribution/config/string_formatting_config.py` that you can customize. It's used to help formatting of the "Copyright" part of the output. These are strings that often come after a comma (like the Inc in "Datadog, Inc.") that should be exceptions to splitting the string on the comma. 
+There's a file at `src/dd_license_attribution/config/string_formatting_config.py` that you can customize. It's used to help formatting of the "Copyright" part of the output. These are strings that often come after a comma (like the Inc in "Datadog, Inc.") that should be exceptions to splitting the string on the comma.
 
 #### Manual repository override configuration
 
@@ -139,11 +150,34 @@ Sometimes `dd-license-attribution` may not detect all dependencies correctly, or
 - **Remove false positives** from your dependency report
 - **Update copyright information** when the detected data is wrong
 
-Use the `--override-spec` parameter to specify your override configuration file:
+##### Creating Overrides Interactively (Recommended)
+
+The easiest way to create overrides is using the **interactive `generate-overrides` command**:
 
 ```bash
-dd-license-attribution --override-spec .ddla-overrides https://github.com/your-org/your-project
+# Generate the SBOM first
+dd-license-attribution generate-sbom-csv https://github.com/owner/repo > LICENSE-3rdparty.csv
+
+# Interactively fix entries with missing information
+dd-license-attribution generate-overrides LICENSE-3rdparty.csv
+
+# Regenerate with overrides applied
+dd-license-attribution generate-sbom-csv https://github.com/owner/repo --override-spec .ddla-overrides > LICENSE-3rdparty.csv
 ```
+
+The `generate-overrides` command will:
+- Analyze your CSV file for entries with missing license or copyright
+- Prompt you interactively to provide the correct information
+- Generate a properly formatted `.ddla-overrides` file
+
+**Options:**
+- `--output` or `-o`: Specify custom output file location
+- `--only-license`: Only fix entries with missing license information
+- `--only-copyright`: Only fix entries with missing copyright information
+
+##### Creating Overrides Manually
+
+Alternatively, you can manually create an override configuration file:
 
 **Quick Example:**
 ```json
@@ -160,6 +194,12 @@ dd-license-attribution --override-spec .ddla-overrides https://github.com/your-o
 ]
 ```
 
+Then use it with the `--override-spec` parameter:
+
+```bash
+dd-license-attribution generate-sbom-csv --override-spec .ddla-overrides https://github.com/your-org/your-project
+```
+
 📖 **For complete documentation, examples, and best practices, see [Override Configuration Guide](overrides.md)**
 
 > **Recommendation**: When using overrides, consider creating a PR or feature request to improve `dd-license-attribution` or the target dependency to add missing information upstream. Overrides should ideally be a temporary measure.
@@ -168,24 +208,36 @@ dd-license-attribution --override-spec .ddla-overrides https://github.com/your-o
 
 #### Basic License Attribution
 ```bash
-dd-license-attribution https://github.com/owner/repo > LICENSE-3rdparty.csv
+dd-license-attribution generate-sbom-csv https://github.com/owner/repo > LICENSE-3rdparty.csv
 ```
 
 #### Deep Scanning with Caching
 ```bash
-dd-license-attribution --deep-scanning --cache-dir ./cache https://github.com/owner/repo > LICENSE-3rdparty.csv
+dd-license-attribution generate-sbom-csv --deep-scanning --cache-dir ./cache https://github.com/owner/repo > LICENSE-3rdparty.csv
 ```
 
 #### Working with Private Repositories
 ```bash
 export GITHUB_TOKEN=your_token
-dd-license-attribution https://github.com/owner/private-repo > LICENSE-3rdparty.csv
+dd-license-attribution generate-sbom-csv https://github.com/owner/private-repo > LICENSE-3rdparty.csv
 ```
 
 #### Using Mirror Repositories
 ```bash
 # Create mirrors.json with your mirror configurations
-dd-license-attribution --use-mirrors=mirrors.json https://github.com/owner/repo > LICENSE-3rdparty.csv
+dd-license-attribution generate-sbom-csv --use-mirrors=mirrors.json https://github.com/owner/repo > LICENSE-3rdparty.csv
+```
+
+#### Interactive Override Generation
+```bash
+# Step 1: Generate initial SBOM
+dd-license-attribution generate-sbom-csv https://github.com/owner/repo > LICENSE-3rdparty.csv
+
+# Step 2: Fix entries with missing information interactively
+dd-license-attribution generate-overrides LICENSE-3rdparty.csv
+
+# Step 3: Regenerate with overrides
+dd-license-attribution generate-sbom-csv --override-spec .ddla-overrides https://github.com/owner/repo > LICENSE-3rdparty.csv
 ```
 
 ### Development and Contributing

--- a/src/dd_license_attribution/adaptors/os.py
+++ b/src/dd_license_attribution/adaptors/os.py
@@ -54,5 +54,10 @@ def open_file(file_path: str) -> str:
                 return file.read()
 
 
+def write_file(file_path: str, content: str) -> None:
+    with open(file_path, "w", encoding="utf-8") as file:
+        file.write(content)
+
+
 def path_join(path: str, *paths: str) -> str:
     return os.path.join(path, *paths)

--- a/src/dd_license_attribution/cli/generate_overrides_command.py
+++ b/src/dd_license_attribution/cli/generate_overrides_command.py
@@ -10,6 +10,7 @@ from typing import Annotated
 
 import typer
 
+from dd_license_attribution.adaptors.os import write_file
 from dd_license_attribution.metadata_collector.metadata import Metadata
 from dd_license_attribution.metadata_collector.strategies.license_3rdparty_metadata_collection_strategy import (  # noqa: E501
     License3rdPartyMetadataCollectionStrategy,
@@ -25,8 +26,6 @@ from dd_license_attribution.overrides_generator.overrides_generator import (
 from dd_license_attribution.overrides_generator.writers.json_overrides_writer import (  # noqa: E501
     JSONOverridesWriter,
 )
-
-from dd_license_attribution.adaptors.os import write_file
 
 
 def only_license_or_copyright_callback() -> (

--- a/src/dd_license_attribution/cli/generate_overrides_command.py
+++ b/src/dd_license_attribution/cli/generate_overrides_command.py
@@ -1,0 +1,251 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+# Command for generating override configuration files
+
+from collections.abc import Callable
+from typing import Annotated
+
+import typer
+
+from dd_license_attribution.metadata_collector.metadata import Metadata
+from dd_license_attribution.metadata_collector.strategies.license_3rdparty_metadata_collection_strategy import (  # noqa: E501
+    License3rdPartyMetadataCollectionStrategy,
+)
+from dd_license_attribution.metadata_collector.strategies.override_strategy import (  # noqa: E501
+    OverrideRule,
+    OverrideTargetField,
+    OverrideType,
+)
+from dd_license_attribution.overrides_generator.overrides_generator import (
+    OverridesGenerator,
+)
+from dd_license_attribution.overrides_generator.writers.json_overrides_writer import (  # noqa: E501
+    JSONOverridesWriter,
+)
+
+from dd_license_attribution.adaptors.os import write_file
+
+
+def only_license_or_copyright_callback() -> (
+    Callable[[typer.Context, typer.CallbackParam, bool], bool | None]
+):
+    """
+    Callback to ensure --only-license and --only-copyright are mutually
+    exclusive.
+    """
+    group = set()
+
+    def callback(
+        ctx: typer.Context, param: typer.CallbackParam, value: bool
+    ) -> bool | None:
+        # Add cli option to group if it was called with a value
+        if (
+            value is True
+            and param.name not in group
+            and (param.name == "only_license" or param.name == "only_copyright")
+        ):
+            group.add(param.name)
+
+        if len(group) == 2:
+            raise typer.BadParameter(
+                "Cannot specify both --only-license and --only-copyright"
+            )
+
+        return value
+
+    return callback
+
+
+only_license_or_copyright_exclusive = only_license_or_copyright_callback()
+
+
+def generate_overrides(
+    csv_file: Annotated[
+        str,
+        typer.Argument(
+            help=(
+                "Path to the LICENSE-3rdparty.csv file to analyze for "
+                "missing license or copyright information."
+            )
+        ),
+    ],
+    output_file: Annotated[
+        str,
+        typer.Option(
+            "--output",
+            "-o",
+            help=(
+                "Path to the output JSON file for overrides. "
+                "Default is .ddla-overrides"
+            ),
+        ),
+    ] = ".ddla-overrides",
+    only_license: Annotated[
+        bool,
+        typer.Option(
+            "--only-license",
+            help=("Only check for entries with missing license information."),
+            callback=only_license_or_copyright_exclusive,
+        ),
+    ] = False,
+    only_copyright: Annotated[
+        bool,
+        typer.Option(
+            "--only-copyright",
+            help=("Only check for entries with missing copyright " "information."),
+            callback=only_license_or_copyright_exclusive,
+        ),
+    ] = False,
+) -> None:
+    """
+    Generate an override configuration file from a LICENSE-3rdparty.csv file.
+
+    This command analyzes a LICENSE-3rdparty.csv file and prompts the user to fix entries with
+    empty license or copyright information, generating a valid .ddla-overrides JSON file.
+    """
+    try:
+        strategy = License3rdPartyMetadataCollectionStrategy(csv_file)
+        metadata_list = strategy.augment_metadata([])
+    except FileNotFoundError:
+        typer.echo(f"Error: File '{csv_file}' not found.", err=True)
+        raise typer.Exit(code=1)
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=1)
+    except Exception as e:
+        typer.echo(f"Error reading CSV file: {e}", err=True)
+        raise typer.Exit(code=1)
+
+    if not metadata_list:
+        typer.echo("Error: CSV file is empty.", err=True)
+        raise typer.Exit(code=1)
+
+    # Find entries with empty license or copyright
+    problematic_entries = []
+    for meta in metadata_list:
+        is_problematic = False
+        if only_license:
+            if not meta.license:
+                is_problematic = True
+        elif only_copyright:
+            if not meta.copyright:
+                is_problematic = True
+        else:
+            if not meta.license or not meta.copyright:
+                is_problematic = True
+
+        if is_problematic:
+            problematic_entries.append(meta)
+
+    if not problematic_entries:
+        typer.echo("No entries with missing license or copyright information found.")
+        return
+
+    num_entries = len(problematic_entries)
+    typer.echo(
+        f"Found {num_entries} entries with missing license or "
+        f"copyright information.\n"
+    )
+
+    # Collect override rules from user input
+    override_rules = []
+
+    for entry in problematic_entries:
+        typer.echo(f"Component: {entry.name}")
+        typer.echo(f"Origin: {entry.origin}")
+        license_display = entry.license if entry.license else "(empty)"
+        typer.echo(f"Current License: {license_display}")
+        copyright_display = entry.copyright if entry.copyright else "(empty)"
+        typer.echo(f"Current Copyright: {copyright_display}")
+
+        # Ask if user wants to fix this entry
+        fix_it = typer.confirm("\nDo you want to fix this entry?", default=True)
+
+        if not fix_it:
+            typer.echo("Skipping...\n")
+            continue
+
+        # Collect the new values
+        typer.echo("\nEnter the corrected information:")
+        typer.echo("(Press Enter to keep the current value)")
+
+        # Ask for origin (show current value as default)
+        new_origin = typer.prompt(
+            "Origin", default=entry.origin if entry.origin else ""
+        )
+
+        # Ask for license (comma-separated list)
+        license_prompt = "License(s) (comma-separated)"
+        current_licenses = ", ".join(entry.license)
+        license_prompt += f" [current: {current_licenses}]"
+        license_input = typer.prompt(license_prompt, default="")
+        # If user pressed Enter (empty input), keep current value
+        if not license_input.strip():
+            new_licenses = entry.license
+        else:
+            new_licenses = [
+                lic.strip() for lic in license_input.split(",") if lic.strip()
+            ]
+        # Ask for copyright (comma-separated list)
+
+        copyright_prompt = "Copyright holder(s) (comma-separated)"
+        current_copyrights = ", ".join(entry.copyright)
+        copyright_prompt += f" [current: {current_copyrights}]"
+        copyright_input = typer.prompt(copyright_prompt, default="")
+        # If user pressed Enter (empty input), keep current value
+        if not copyright_input.strip():
+            new_copyrights = entry.copyright
+        else:
+            new_copyrights = [
+                cr.strip() for cr in copyright_input.split(",") if cr.strip()
+            ]
+
+        # Create the override rule using the existing OverrideRule structure
+        # Build the target dictionary with OverrideTargetField keys
+        target: dict[OverrideTargetField, str] = {
+            OverrideTargetField.COMPONENT: str(entry.name),
+            OverrideTargetField.ORIGIN: str(entry.origin),
+        }
+
+        # Create the replacement Metadata object
+        replacement = Metadata(
+            name=entry.name,
+            origin=new_origin,
+            version=entry.version,
+            local_src_path=None,
+            license=new_licenses,
+            copyright=new_copyrights,
+        )
+
+        override_rule = OverrideRule(
+            override_type=OverrideType.REPLACE,
+            target=target,
+            replacement=replacement,
+        )
+
+        override_rules.append(override_rule)
+        typer.echo("✓ Override rule created.\n")
+
+    # Generate the override rules JSON using the generator
+    if override_rules:
+        try:
+            json_writer = JSONOverridesWriter()
+            generator = OverridesGenerator(json_writer)
+            json_output = generator.generate_overrides(override_rules)
+
+            # Write the JSON string to the output file
+            write_file(output_file, json_output)
+
+            num_rules = len(override_rules)
+            typer.echo(
+                f"\n✓ Successfully created override file: {output_file} "
+                f"with {num_rules} rule(s)."
+            )
+        except Exception as e:
+            typer.echo(f"Error writing override file: {e}", err=True)
+            raise typer.Exit(code=1)
+    else:
+        typer.echo("\nNo override rules were created.")

--- a/src/dd_license_attribution/cli/main_cli.py
+++ b/src/dd_license_attribution/cli/main_cli.py
@@ -7,9 +7,24 @@
 
 import typer
 
-from dd_license_attribution.cli.generate_sbom_csv_command import generate_sbom_csv
+from dd_license_attribution.cli.generate_overrides_command import (
+    generate_overrides,
+)
+from dd_license_attribution.cli.generate_sbom_csv_command import (
+    generate_sbom_csv,
+)
 
-app = typer.Typer(add_completion=False, no_args_is_help=True)
+app = typer.Typer(add_completion=False)
 app.command()(generate_sbom_csv)
+app.command()(generate_overrides)
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        ctx.exit(2)
+
+
 if __name__ == "__main__":
     app()

--- a/tests/unit/test_generate_overrides_command.py
+++ b/tests/unit/test_generate_overrides_command.py
@@ -1,0 +1,524 @@
+# Unless explicitly stated otherwise all files in this repository are
+# licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from dd_license_attribution.metadata_collector.metadata import Metadata
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a fresh CLI runner for each test."""
+    return CliRunner()
+
+
+@pytest.fixture
+def app() -> typer.Typer:
+    """
+    Create a fresh app instance for each test.
+
+    This avoids callback state issues.
+    """
+    # Remove the module from sys.modules to force a fresh import
+    modules_to_reload = [
+        "dd_license_attribution.cli.generate_overrides_command",
+        "dd_license_attribution.cli.main_cli",
+    ]
+    for mod in modules_to_reload:
+        if mod in sys.modules:
+            del sys.modules[mod]
+
+    # Import fresh
+    from dd_license_attribution.cli.main_cli import app as fresh_app
+
+    return fresh_app
+
+
+def test_file_not_found(app: typer.Typer, runner: CliRunner) -> None:
+    """Test that the command handles missing CSV files gracefully."""
+    result = runner.invoke(app, ["generate-overrides", "nonexistent.csv"], color=False)
+    assert result.exit_code == 1
+    assert "Error: File 'nonexistent.csv' not found." in result.stderr
+
+
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_empty_csv_file(
+    mock_strategy_augment_metadata: Mock, app: typer.Typer, runner: CliRunner
+) -> None:
+    """Test that the command handles empty CSV files correctly."""
+    mock_strategy_augment_metadata.return_value = []
+
+    result = runner.invoke(app, ["generate-overrides", "empty.csv"], color=False)
+    assert result.exit_code == 1
+    assert "Error: CSV file is empty." in result.stderr
+
+
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_invalid_csv_file(
+    mock_strategy_augement_metadata: Mock, app: typer.Typer, runner: CliRunner
+) -> None:
+    """Test that the command handles invalid CSV files (ValueError)."""
+    mock_strategy_augement_metadata.side_effect = ValueError("Invalid CSV format")
+
+    result = runner.invoke(app, ["generate-overrides", "invalid.csv"], color=False)
+    assert result.exit_code == 1
+    assert "Error: Invalid CSV format" in result.stderr
+
+
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_no_problematic_entries(
+    mock_strategy_augment_metadata: Mock, app: typer.Typer, runner: CliRunner
+) -> None:
+    """Test command handles CSV files with no problematic entries."""
+    metadata = Metadata(
+        name="test-package",
+        version="1.0.0",
+        origin="https://github.com/test/test",
+        local_src_path=None,
+        license=["MIT"],
+        copyright=["Copyright 2024 Test Corp"],
+    )
+    mock_strategy_augment_metadata.return_value = [metadata]
+
+    result = runner.invoke(app, ["generate-overrides", "good.csv"], color=False)
+    assert result.exit_code == 0
+    assert (
+        "No entries with missing license or copyright information found."
+        in result.stdout
+    )
+
+
+@patch("dd_license_attribution.adaptors.os.write_file")
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command.OverridesGenerator.generate_overrides"
+)
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_user_skips_all_entries(
+    mock_strategy_augment_metadata: Mock,
+    mock_generator_generate_overrides: Mock,
+    mock_file: Mock,
+    app: typer.Typer,
+    runner: CliRunner,
+) -> None:
+    """Test that the command handles the user skipping all entries."""
+    metadata = Metadata(
+        name="test-package",
+        version="1.0.0",
+        origin="https://github.com/test/test",
+        local_src_path=None,
+        license=[],
+        copyright=["Copyright 2024 Test Corp"],
+    )
+    mock_strategy_augment_metadata.return_value = [metadata]
+
+    # Simulate user saying "no" to fixing the entry
+    result = runner.invoke(
+        app, ["generate-overrides", "test.csv"], input="n\n", color=False
+    )
+    assert result.exit_code == 0
+    assert "No override rules were created." in result.stdout
+
+
+@patch("dd_license_attribution.cli.generate_overrides_command.write_file")
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command.OverridesGenerator.generate_overrides"
+)
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_successful_override_generation(
+    mock_strategy_augment_metadata: Mock,
+    mock_generator_generate_overrides: Mock,
+    mock_file: Mock,
+    app: typer.Typer,
+    runner: CliRunner,
+) -> None:
+    """Test successful generation of override file with user input."""
+    # Create metadata with missing license
+    metadata = Metadata(
+        name="test-package",
+        version="1.0.0",
+        origin="https://github.com/test/test",
+        local_src_path=None,
+        license=[],
+        copyright=["Copyright 2024 Test Corp"],
+    )
+    mock_strategy_augment_metadata.return_value = [metadata]
+
+    # Mock the generator
+    mock_generator_generate_overrides.return_value = '{"overrides": []}'
+
+    # Simulate user input: yes to fix, keep origin, add MIT license,
+    # keep copyright
+    user_input = "y\n\nMIT\n\n"
+    result = runner.invoke(
+        app, ["generate-overrides", "test.csv"], input=user_input, color=False
+    )
+
+    assert result.exit_code == 0
+    assert "Successfully created override file: .ddla-overrides" in result.stdout
+    assert "with 1 rule(s)." in result.stdout
+    mock_file.assert_called_once_with(".ddla-overrides", '{"overrides": []}')
+
+
+@patch("dd_license_attribution.cli.generate_overrides_command.write_file")
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command.OverridesGenerator.generate_overrides"
+)
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_custom_output_file(
+    mock_strategy_augment_metadata: Mock,
+    mock_generator_generate_overrides: Mock,
+    mock_file: Mock,
+    app: typer.Typer,
+    runner: CliRunner,
+) -> None:
+    """Test that custom output file path is respected."""
+    metadata = Metadata(
+        name="test-package",
+        version="1.0.0",
+        origin="https://github.com/test/test",
+        local_src_path=None,
+        license=[],
+        copyright=["Copyright 2024 Test Corp"],
+    )
+    mock_strategy_augment_metadata.return_value = [metadata]
+
+    mock_generator_generate_overrides.return_value = '{"overrides": []}'
+
+    user_input = "y\n\nMIT\n\n"
+    result = runner.invoke(
+        app,
+        [
+            "generate-overrides",
+            "test.csv",
+            "--output",
+            "custom-overrides.json",
+        ],
+        input=user_input,
+        color=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Successfully created override file: custom-overrides.json" in result.stdout
+    mock_file.assert_called_once_with("custom-overrides.json", '{"overrides": []}')
+
+
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_only_license_option(
+    mock_strategy_augment_metadata: Mock, app: typer.Typer, runner: CliRunner
+) -> None:
+    """Test that --only-license filters entries correctly."""
+    metadata_missing_license = Metadata(
+        name="test-package-1",
+        version="1.0.0",
+        origin="https://github.com/test/test1",
+        local_src_path=None,
+        license=[],
+        copyright=["Copyright 2024 Test Corp"],
+    )
+    # Create metadata with missing copyright but present license
+    metadata_missing_copyright = Metadata(
+        name="test-package-2",
+        version="1.0.0",
+        origin="https://github.com/test/test2",
+        local_src_path=None,
+        license=["MIT"],
+        copyright=[],
+    )
+    mock_strategy_augment_metadata.return_value = [
+        metadata_missing_license,
+        metadata_missing_copyright,
+    ]
+
+    # Skip all entries to avoid dealing with prompts
+    result = runner.invoke(
+        app,
+        ["generate-overrides", "test.csv", "--only-license"],
+        input="n\n",
+        color=False,
+    )
+
+    assert result.exit_code == 0
+    # Should only show 1 entry (the one missing license)
+    assert (
+        "Found 1 entries with missing license or copyright information."
+        in result.stdout
+    )
+
+
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_only_copyright_option(
+    mock_strategy_augment_metadata: Mock, app: typer.Typer, runner: CliRunner
+) -> None:
+    """Test that --only-copyright filters entries correctly."""
+    metadata_missing_license = Metadata(
+        name="test-package-1",
+        version="1.0.0",
+        origin="https://github.com/test/test1",
+        local_src_path=None,
+        license=[],
+        copyright=["Copyright 2024 Test Corp"],
+    )
+    # Create metadata with missing copyright but present license
+    metadata_missing_copyright = Metadata(
+        name="test-package-2",
+        version="1.0.0",
+        origin="https://github.com/test/test2",
+        local_src_path=None,
+        license=["MIT"],
+        copyright=[],
+    )
+    mock_strategy_augment_metadata.return_value = [
+        metadata_missing_license,
+        metadata_missing_copyright,
+    ]
+
+    # Skip all entries to avoid dealing with prompts
+    result = runner.invoke(
+        app,
+        ["generate-overrides", "test.csv", "--only-copyright"],
+        input="n\n",
+        color=False,
+    )
+
+    assert result.exit_code == 0
+    # Should only show 1 entry (the one missing copyright)
+    assert (
+        "Found 1 entries with missing license or copyright information."
+        in result.stdout
+    )
+
+
+def test_mutually_exclusive_options(app: typer.Typer, runner: CliRunner) -> None:
+    """Test that --only-license and --only-copyright can't be used together."""
+    result = runner.invoke(
+        app,
+        [
+            "generate-overrides",
+            "test.csv",
+            "--only-license",
+            "--only-copyright",
+        ],
+        color=False,
+    )
+    assert result.exit_code == 2
+    # Error message is present in output, possibly with formatting
+    output = result.stdout + result.stderr
+    assert "--only-license" in output
+    assert "--only-copyright" in output
+
+
+@patch("dd_license_attribution.cli.generate_overrides_command.write_file")
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command.OverridesGenerator.generate_overrides"
+)
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_multiple_entries_mixed_responses(
+    mock_strategy_augment_metadata: Mock,
+    mock_generator_generate_overrides: Mock,
+    mock_file: Mock,
+    app: typer.Typer,
+    runner: CliRunner,
+) -> None:
+    """Test handling multiple entries with mixed user responses."""
+    metadata1 = Metadata(
+        name="test-package-1",
+        version="1.0.0",
+        origin="https://github.com/test/test1",
+        local_src_path=None,
+        license=[],
+        copyright=["Copyright 2024 Test Corp"],
+    )
+    metadata2 = Metadata(
+        name="test-package-2",
+        version="2.0.0",
+        origin="https://github.com/test/test2",
+        local_src_path=None,
+        license=["MIT"],
+        copyright=[],
+    )
+    mock_strategy_augment_metadata.return_value = [metadata1, metadata2]
+    mock_generator_generate_overrides.return_value = '{"overrides": []}'
+
+    # Fix first entry, skip second entry
+    user_input = "y\n\nMIT\n\nn\n"
+    result = runner.invoke(
+        app, ["generate-overrides", "test.csv"], input=user_input, color=False
+    )
+
+    assert result.exit_code == 0
+    assert (
+        "Found 2 entries with missing license or copyright information."
+        in result.stdout
+    )
+    assert "Successfully created override file: .ddla-overrides" in result.stdout
+    assert "with 1 rule(s)." in result.stdout
+
+
+@patch("dd_license_attribution.cli.generate_overrides_command.write_file")
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command.OverridesGenerator.generate_overrides"
+)
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_error_writing_output_file(
+    mock_strategy_augment_metadata: Mock,
+    mock_generator_generate_overrides: Mock,
+    mock_file: Mock,
+    app: typer.Typer,
+    runner: CliRunner,
+) -> None:
+    """Test that errors during file writing are handled gracefully."""
+    metadata = Metadata(
+        name="test-package",
+        version="1.0.0",
+        origin="https://github.com/test/test",
+        local_src_path=None,
+        license=[],
+        copyright=["Copyright 2024 Test Corp"],
+    )
+    mock_strategy_augment_metadata.return_value = [metadata]
+
+    mock_generator_generate_overrides.return_value = '{"overrides": []}'
+
+    # Simulate file write error
+    mock_file.side_effect = IOError("Permission denied")
+
+    user_input = "y\n\nMIT\n\n"
+    result = runner.invoke(
+        app, ["generate-overrides", "test.csv"], input=user_input, color=False
+    )
+
+    assert result.exit_code == 1
+    assert "Error writing override file: Permission denied" in result.stderr
+
+
+@patch("dd_license_attribution.cli.generate_overrides_command.write_file")
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command.OverridesGenerator.generate_overrides"
+)
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_comma_separated_licenses_and_copyrights(
+    mock_strategy_augment_metadata: Mock,
+    mock_generator_generate_overrides: Mock,
+    mock_file: Mock,
+    app: typer.Typer,
+    runner: CliRunner,
+) -> None:
+    """Test that comma-separated licenses and copyrights are parsed."""
+    metadata = Metadata(
+        name="test-package",
+        version="1.0.0",
+        origin="https://github.com/test/test",
+        local_src_path=None,
+        license=[],
+        copyright=[],
+    )
+    mock_strategy_augment_metadata.return_value = [metadata]
+
+    mock_generator_generate_overrides.return_value = '{"overrides": []}'
+
+    # Provide multiple licenses and copyrights separated by commas
+    user_input = (
+        "y\n\nMIT, Apache-2.0\n"
+        "Copyright 2024 Test Corp, Copyright 2024 Another Corp\n"
+    )
+    result = runner.invoke(
+        app, ["generate-overrides", "test.csv"], input=user_input, color=False
+    )
+
+    assert result.exit_code == 0
+    assert "Successfully created override file: .ddla-overrides" in result.stdout
+
+    # Verify that generate_overrides was called with proper rules
+    mock_generator_generate_overrides.assert_called_once()
+    override_rules = mock_generator_generate_overrides.call_args[0][0]
+    assert len(override_rules) == 1
+    assert override_rules[0].replacement.license == ["MIT", "Apache-2.0"]
+    assert override_rules[0].replacement.copyright == [
+        "Copyright 2024 Test Corp",
+        "Copyright 2024 Another Corp",
+    ]
+
+
+@patch("dd_license_attribution.cli.generate_overrides_command.write_file")
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command.OverridesGenerator.generate_overrides"
+)
+@patch(
+    "dd_license_attribution.cli.generate_overrides_command."
+    "License3rdPartyMetadataCollectionStrategy.augment_metadata"
+)
+def test_keep_current_values_on_empty_input(
+    mock_strategy_augment_metadata: Mock,
+    mock_generator_generate_overrides: Mock,
+    mock_file: Mock,
+    app: typer.Typer,
+    runner: CliRunner,
+) -> None:
+    """Test that pressing Enter keeps current values."""
+    metadata = Metadata(
+        name="test-package",
+        version="1.0.0",
+        origin="https://github.com/test/test",
+        local_src_path=None,
+        license=["MIT"],
+        copyright=[],
+    )
+    mock_strategy_augment_metadata.return_value = [metadata]
+
+    mock_generator_generate_overrides.return_value = '{"overrides": []}'
+
+    # Press Enter for origin, license (keep), and provide new copyright
+    user_input = "y\n\n\nCopyright 2024 Test Corp\n"
+    result = runner.invoke(
+        app, ["generate-overrides", "test.csv"], input=user_input, color=False
+    )
+
+    assert result.exit_code == 0
+
+    # Verify that the original license was kept
+    override_rules = mock_generator_generate_overrides.call_args[0][0]
+    assert len(override_rules) == 1
+    assert override_rules[0].replacement.license == ["MIT"]
+    assert override_rules[0].replacement.copyright == ["Copyright 2024 Test Corp"]

--- a/tests/unit/test_generate_sbom_csv_command.py
+++ b/tests/unit/test_generate_sbom_csv_command.py
@@ -15,7 +15,11 @@ runner = CliRunner()
 
 
 def test_basic_run() -> None:
-    result = runner.invoke(app, ["test", "--no-gh-auth"], color=False)
+    result = runner.invoke(
+        app,
+        ["generate-sbom-csv", "test", "--no-gh-auth"],
+        color=False,
+    )
     assert result.exit_code == 0
 
 
@@ -24,7 +28,7 @@ def test_no_github_auth() -> None:
     original_github_token = os.environ.pop("GITHUB_TOKEN", None)
 
     try:
-        result = runner.invoke(app, ["test"], color=False)
+        result = runner.invoke(app, ["generate-sbom-csv", "test"], color=False)
         assert result.exit_code == 2
         assert "Invalid value for '--github-token'" in result.output_bytes.decode(
             "utf-8", "ignore"
@@ -36,12 +40,21 @@ def test_no_github_auth() -> None:
 
 
 def test_github_auth_param() -> None:
-    result = runner.invoke(app, ["test", "--github-token=12345"], color=False)
+    result = runner.invoke(
+        app,
+        ["generate-sbom-csv", "test", "--github-token=12345"],
+        color=False,
+    )
     assert result.exit_code == 0
 
 
 def test_github_auth_env() -> None:
-    result = runner.invoke(app, ["test"], env={"GITHUB_TOKEN": "12345"}, color=False)
+    result = runner.invoke(
+        app,
+        ["generate-sbom-csv", "test"],
+        env={"GITHUB_TOKEN": "12345"},
+        color=False,
+    )
     assert result.exit_code == 0
 
 
@@ -71,7 +84,7 @@ def test_skip_strategies_options(
     args = ["--no-gh-auth"] + arg
     result = runner.invoke(
         app,
-        ["https://github.com/org/repo"] + args,
+        ["generate-sbom-csv", "https://github.com/org/repo"] + args,
     )
     assert result.exit_code == 0
 
@@ -96,6 +109,7 @@ def test_skip_all_strategies(
     result = runner.invoke(
         app,
         [
+            "generate-sbom-csv",
             "https://github.com/org/repo",
             "--no-gh-auth",
             "--no-pypi-strategy",
@@ -116,7 +130,7 @@ def test_skip_all_strategies(
 
 
 def test_missing_package() -> None:
-    result = runner.invoke(app, color=False)
+    result = runner.invoke(app, ["generate-sbom-csv"], color=False)
     assert result.exit_code == 2
     assert "Missing argument 'PACKAGE'." in result.stderr
 
@@ -138,6 +152,7 @@ def test_use_mirrors_invalid_json(
     result = runner.invoke(
         app,
         [
+            "generate-sbom-csv",
             "--use-mirrors=test.json",
             "--no-gh-auth",
             "--log-level=DEBUG",
@@ -175,11 +190,12 @@ def test_use_mirrors_valid_config(
     result = runner.invoke(
         app,
         [
+            "generate-sbom-csv",
             "--use-mirrors=test.json",
             "--no-gh-auth",
             "--log-level=DEBUG",
             "--",
-            "https://github.com/DataDog/test",
+            "test",
         ],
         color=False,
     )
@@ -187,7 +203,11 @@ def test_use_mirrors_valid_config(
 
 
 def test_cache_ttl_without_cache_dir() -> None:
-    result = runner.invoke(app, ["test", "--cache-ttl=10"], color=False)
+    result = runner.invoke(
+        app,
+        ["generate-sbom-csv", "test", "--cache-ttl=10"],
+        color=False,
+    )
     assert result.exit_code == 2
     assert "Invalid value for '--cache-ttl'" in result.stderr
 
@@ -195,7 +215,12 @@ def test_cache_ttl_without_cache_dir() -> None:
 def test_transitive_root_same_time() -> None:
     result = runner.invoke(
         app,
-        ["test", "--only-transitive-dependencies", "--only-root-project"],
+        [
+            "generate-sbom-csv",
+            "test",
+            "--only-transitive-dependencies",
+            "--only-root-project",
+        ],
         color=False,
     )
     assert result.exit_code == 2


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [x] Documentation Update

## Description

This PR adds a new subcommand to `dd-license-attribution` to interactively generate a valid .ddla-overrides based on an existing `LICENSE-3rdparty.csv`.

The `README.md` and `overrides.md` changes in this PR explain how this new subcommand works, but basically you need to run it this way:

`dd-license-attribution generate-overrides LICENSE-3rdparty.csv -o new-ddla-overrides.json` 

⚠️ **BREAKING CHANGES**: once we merge this new subcommand, the existing functionality (generating the `LICENSE-3rdparty.csv` file will be under a new subcommand `generate-sbom-csv`, instead of being a top command. This PR includes the needed changes to the existing documentation. Once we merge it, though, we would need to tag a new release, as this represents a major change.


