### PR TITLE
Caching dependencies between test runs

### DIFF
--- a/.github/workflows/coverage-unit-test.yml
+++ b/.github/workflows/coverage-unit-test.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #v6.0.0
         with:
           python-version: "3.11"
+          cache: 'pip' # caching pip dependencies
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.11"
+          cache: 'pip' # caching pip dependencies
 
       - name: Set up Golang
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # 6.0.0


### PR DESCRIPTION
Following https://github.com/actions/setup-python/tree/e797f83bcb11b83ae66e0230d6156d7c80228e7c/?tab=readme-ov-file#caching-packages-dependencies

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update
- [x] CI Improvement

## Description

The python action allows to cache the dependencies installed between CI runs. Enabling it.

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
