### PR TITLE
Fix setting root package name for npm strategy

### DIFF
--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -448,6 +448,8 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
             )
             return updated_metadata
 
+        self._enrich_root_package_from_package_json(package_json_data, updated_metadata)
+
         # Early return for ONLY_ROOT_PROJECT - no need to run npm install
         if self.only_root_project:
             return updated_metadata

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -1240,8 +1240,9 @@ def test_npm_collection_strategy_with_yarn_project(
     # Should have root package + 2 dependencies
     assert len(result) == 3
 
-    # Check root package metadata remains unchanged
-    assert result[0].name == "package1"
+    # Check root package metadata was enriched from package.json
+    assert result[0].name == "test-package"  # Enriched from package.json
+    assert result[0].version == "1.0.0"  # Enriched from package.json
     assert result[0].origin == "https://github.com/org/package1"
 
     # Check dependencies were added
@@ -1328,7 +1329,8 @@ def test_npm_collection_strategy_yarn_not_installed(
     with caplog.at_level(logging.ERROR):
         result = strategy.augment_metadata(initial_metadata)
 
-    # Should return original metadata (no dependencies, root unchanged)
+    # Should return metadata with root enriched from package.json (no dependencies)
     assert len(result) == 1
-    assert result[0].name == "package1"
+    assert result[0].name == "test-package"  # Enriched from package.json
+    assert result[0].version == "1.0.0"  # Enriched from package.json
     assert any("Yarn is not installed" in record.message for record in caplog.records)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

Previously it would fall back to the repo url, now it correctly uses the name from the `package.json` file.

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
