### PR TITLE
[OSPO-474] Improvements to generate overrides

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -66,3 +66,7 @@ jobs:
           name: ddla-output
           path: ddla-output.txt
           if-no-files-found: error
+
+      - name: Test generate-overrides command with clean CSV
+        run: |
+          dd-license-attribution generate-overrides LICENSE-3rdparty.csv -o test-overrides.json

--- a/src/dd_license_attribution/utils/custom_splitting.py
+++ b/src/dd_license_attribution/utils/custom_splitting.py
@@ -5,21 +5,57 @@
 # (https://www.datadoghq.com/).
 # Copyright 2025-present Datadog, Inc.
 
+import csv
+from io import StringIO
+
 
 class CustomSplit:
-    def __init__(self, protected_terms: list[str]):
-        self.protected_terms = protected_terms
+    def __init__(self, protected_terms: list[str] | None = None):
+        """
+        Initialize CustomSplit with optional protected terms.
 
-    def custom_split(self, text: str, delimiter: str) -> list[str]:
-        parts = text.split(delimiter)
-        result = [parts[0].strip()]
-        for string in parts[1:]:
-            string = string.strip()
-            if self._should_split(string):
-                result.append(string)
-            else:
-                result[-1] += f"{delimiter} {string}"
-        return result
+        Args:
+            protected_terms: List of terms that should not be split.
+                           If None, no term-based protection is applied.
+        """
+        self.protected_terms = protected_terms or []
+
+    def custom_split(self, input_string: str, delimiter: str = ",") -> list[str]:
+        """
+        Parse a delimited string with support for quoted values and
+        protected terms.
+
+        This method combines CSV parsing (for quote handling) with
+        protected terms logic.
+        """
+
+        if not input_string.strip():
+            return []
+
+        try:
+            reader = csv.reader(
+                StringIO(input_string), delimiter=delimiter, skipinitialspace=True
+            )
+            parsed_values = next(reader)
+            parsed_values = [v.strip() for v in parsed_values if v.strip()]
+        except (csv.Error, StopIteration):
+            # If CSV parsing fails, fall back to string split
+            parsed_values = [
+                v.strip() for v in input_string.split(delimiter) if v.strip()
+            ]
+
+        if self.protected_terms:
+            # Re-merge items that should be protected
+            result = []
+            for value in parsed_values:
+                if result and not self._should_split(value):
+                    # This value should be merged with the previous one
+                    result[-1] += f"{delimiter} {value}"
+                else:
+                    result.append(value)
+            parsed_values = result
+
+        return parsed_values
 
     def _should_split(self, text: str) -> bool:
         return not any(

--- a/src/dd_license_attribution/utils/custom_splitting.py
+++ b/src/dd_license_attribution/utils/custom_splitting.py
@@ -46,7 +46,7 @@ class CustomSplit:
 
         if self.protected_terms:
             # Re-merge items that should be protected
-            result = []
+            result: list[str] = []
             for value in parsed_values:
                 if result and not self._should_split(value):
                     # This value should be merged with the previous one

--- a/tests/unit/test_custom_splitting.py
+++ b/tests/unit/test_custom_splitting.py
@@ -1,0 +1,73 @@
+# Unless explicitly stated otherwise all files in this repository are
+# licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+from dd_license_attribution.utils.custom_splitting import CustomSplit
+
+
+def test_custom_split_simple_values() -> None:
+    """Test CustomSplit with simple comma-separated values."""
+    splitter = CustomSplit()
+    result = splitter.custom_split("MIT, Apache-2.0, BSD-3-Clause")
+    assert result == ["MIT", "Apache-2.0", "BSD-3-Clause"]
+
+
+def test_custom_split_quoted_values() -> None:
+    """Test CustomSplit with quoted values containing commas."""
+    splitter = CustomSplit()
+    result = splitter.custom_split('"Datadog, Inc.", Google LLC')
+    assert result == ["Datadog, Inc.", "Google LLC"]
+
+
+def test_custom_split_with_protected_terms() -> None:
+    """Test CustomSplit with protected terms."""
+    splitter = CustomSplit(protected_terms=["inc."])
+    result = splitter.custom_split("Datadog, Inc., Google LLC")
+    assert result == ["Datadog, Inc.", "Google LLC"]
+
+
+def test_custom_split_quotes_and_protected_terms() -> None:
+    """Test CustomSplit with both quotes and protected terms."""
+    splitter = CustomSplit(protected_terms=["llc"])
+    result = splitter.custom_split('"Datadog, Inc.", Google, LLC, Apple')
+    assert result == ["Datadog, Inc.", "Google, LLC", "Apple"]
+
+
+def test_custom_split_protected_terms_without_quotes() -> None:
+    """Test that protected terms work without quotes."""
+    splitter = CustomSplit(protected_terms=["corp."])
+    input_str = "Test, Corp., Google"
+    result = splitter.custom_split(input_str)
+    assert result == ["Test, Corp.", "Google"]
+
+
+def test_custom_split_protected_terms_blank() -> None:
+    """Test that protected terms work without quotes and blank values."""
+    splitter = CustomSplit(protected_terms=["corp."])
+    input_str = "Test, Corp., , Google"
+    result = splitter.custom_split(input_str)
+    assert result == ["Test, Corp.", "Google"]
+
+
+def test_custom_split_empty_string() -> None:
+    """Test CustomSplit with empty string."""
+    splitter = CustomSplit()
+    assert splitter.custom_split("") == []
+    assert splitter.custom_split("   ") == []
+
+
+def test_custom_split_different_delimiter() -> None:
+    """Test CustomSplit with a different delimiter."""
+    splitter = CustomSplit()
+    result = splitter.custom_split("MIT; Apache-2.0; BSD", delimiter=";")
+    assert result == ["MIT", "Apache-2.0", "BSD"]
+
+
+def test_custom_split_no_protected_terms() -> None:
+    """Test CustomSplit initialized without protected terms."""
+    splitter = CustomSplit(protected_terms=None)
+    result = splitter.custom_split("MIT, Apache-2.0")
+    assert result == ["MIT", "Apache-2.0"]


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

This PR improves the `generate-overrides` command allowing the user to add new copyrights with commas, by quoting the copyright holders. This is done by improving the CustomSplit class to use the CSV reader, which supports quoting. 

Added tests for the CustomSplit class, that didn't have before.

Also, added a simple integration test for the `generate-overrides` subcommand.

