### PR TITLE
fix: remove extra trailing newline in CSV output

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -88,4 +88,3 @@
 "webencodings","https://github.com/gsnedders/python-webencodings","['BSD']","['Geoffrey Sneddon']"
 "xmltodict","https://github.com/martinblech/xmltodict","['MIT']","['Martin Blech']"
 "zipp","https://github.com/jaraco/zipp","['MIT']","['Jason R. Coombs']"
-

--- a/src/dd_license_attribution/cli/generate_sbom_csv_command.py
+++ b/src/dd_license_attribution/cli/generate_sbom_csv_command.py
@@ -528,7 +528,7 @@ def generate_sbom_csv(
     output = csv_reporter.generate_report(metadata)
     if temp_dir is not None:
         temp_dir.cleanup()
-    print(output)
+    print(output, end="")
     if override_strategy is not None and len(override_strategy.unused_targets()) != 0:
         logger.warning("Not all targets in the override spec file were used.")
         logger.warning(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

The `print()` function was adding an automatic newline after the CSV content, which already included a trailing newline from the CSV writer. This resulted in two newlines at the end of the output instead of one.

What is worse, is that the CSV writer uses Windows-style line breaks (`\r\n`), while the `print()` function uses UNIX-style line breaks, so without this change the file would end in `\r\n\n`.

Suppress the automatic newline by using `print(output, end='')` to ensure the output ends with exactly one newline as expected.
## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
