### PR TITLE
Make project URLs for PyPI case insensitive

### DIFF
--- a/.ddla-overrides
+++ b/.ddla-overrides
@@ -227,11 +227,11 @@
   {
     "override_type": "replace",
     "target": {
-      "origin": "pypi:cryptography"
+      "origin": "https://github.com/pyca/cryptography/"
     },
     "replacement": {
       "name": "cryptography",
-      "origin": "pypi:cryptography",
+      "origin": "https://github.com/pyca/cryptography",
       "license": [
         "Apache-2.0 OR BSD-3-Clause"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Added
-- Support for GitHub renamed/transferred repositories
-- Support for Yarn package manager in npm collection
+### Added
+- Support for GitHub renamed/transferred repositories
+- Support for Yarn package manager in npm collection
+
+### Changed
+- PyPI collection strategy now performs case-insensitive key matching for project_urls dictionary to better handle different key capitalizations from PyPI metadata
 
 ## [0.5.0] - 2025-10-29
 

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -18,7 +18,7 @@
 "colorama","https://github.com/tartley/colorama","['BSD-3-Clause']","['Jonathan Hartley']"
 "commoncode","https://github.com/aboutcode-org/commoncode","['Apache-2.0']","['nexB. Inc. and others']"
 "container-inspector","https://github.com/aboutcode-org/container-inspector","['Apache-2.0']","['nexB. Inc. and others']"
-"cryptography","pypi:cryptography","['Apache-2.0 OR BSD-3-Clause']","['The cryptography developers <cryptography-dev@python.org>']"
+"cryptography","https://github.com/pyca/cryptography","['Apache-2.0 OR BSD-3-Clause']","['The cryptography developers <cryptography-dev@python.org>']"
 "debian-inspector","https://github.com/aboutcode-org/debian-inspector","['Apache-2.0 AND BSD-3-Clause AND MIT']","['nexB. Inc. and others']"
 "dockerfile-parse","https://github.com/containerbuildsystem/dockerfile-parse","['BSD']","['Jiri Popelka']"
 "dparse2","https://github.com/aboutcode-org/dparse2","['MIT']","['maintained by AboutCode.org', 'originally from Jannis Gebauer']"

--- a/src/dd_license_attribution/metadata_collector/strategies/pypi_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/pypi_collection_strategy.py
@@ -84,6 +84,7 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
 
             origin = "pypi:" + dependency
             project_urls = {}
+            project_urls_lower = {}
             # Depending on the pypi package, the GitHub URL is in different keys
             if "project_urls" in pypi_info and pypi_info["project_urls"] is not None:
                 project_urls = pypi_info["project_urls"]
@@ -98,25 +99,32 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
                     del project_urls[key]
                     continue
                 project_urls[key] = project_urls[key].replace("http://", "https://")
+                project_urls_lower[key.lower()] = project_urls[key]
 
-            if "Homepage" in project_urls and validate_git_url(
-                project_urls["Homepage"]
+            if "homepage" in project_urls_lower and validate_git_url(
+                project_urls_lower["homepage"]
             ):
-                origin = project_urls["Homepage"]
-            if "GitHub" in project_urls and validate_git_url(project_urls["GitHub"]):
-                origin = project_urls["GitHub"]
-            if "Repository" in project_urls and validate_git_url(
-                project_urls["Repository"]
+                origin = project_urls_lower["homepage"]
+            if "github" in project_urls_lower and validate_git_url(
+                project_urls_lower["github"]
             ):
-                origin = project_urls["Repository"]
-            if "Code" in project_urls and validate_git_url(project_urls["Code"]):
-                origin = project_urls["Code"]
-            if "Source Code" in project_urls and validate_git_url(
-                project_urls["Source Code"]
+                origin = project_urls_lower["github"]
+            if "repository" in project_urls_lower and validate_git_url(
+                project_urls_lower["repository"]
             ):
-                origin = project_urls["Source Code"]
-            if "Source" in project_urls and validate_git_url(project_urls["Source"]):
-                origin = project_urls["Source"]
+                origin = project_urls_lower["repository"]
+            if "code" in project_urls_lower and validate_git_url(
+                project_urls_lower["code"]
+            ):
+                origin = project_urls_lower["code"]
+            if "source code" in project_urls_lower and validate_git_url(
+                project_urls_lower["source code"]
+            ):
+                origin = project_urls_lower["source code"]
+            if "source" in project_urls_lower and validate_git_url(
+                project_urls_lower["source"]
+            ):
+                origin = project_urls_lower["source"]
 
             find_pkg = next(
                 (

--- a/tests/unit/test_pypi_collection_strategy.py
+++ b/tests/unit/test_pypi_collection_strategy.py
@@ -719,3 +719,197 @@ def test_pypi_collection_strategy_ignores_none_project_urls(
         "cache_dir/20220101_000000Z/org_package1_virtualenv"
     )
     mock_request.assert_called_once_with("https://pypi.org/pypi/package3/1.2.3/json")
+
+
+def test_pypi_collection_strategy_handles_case_insensitive_project_url_keys(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Test that project_urls keys are matched case-insensitively.
+
+    This test verifies that keys like 'Homepage', 'HOMEPAGE', 'homepage',
+    'GitHub', 'GITHUB', 'github', etc. are all recognized and handled correctly.
+    """
+    source_code_manager_mock = mocker.Mock()
+    source_code_manager_mock.get_canonical_urls.return_value = (
+        "github.com/org/package1",
+        None,
+    )
+    source_code_manager_mock.get_code.return_value = SourceCodeReference(
+        repo_url="https://github.com/org/package1",
+        branch="main",
+        local_root_path="cache_dir/20220101_000000Z/org-package1/main",
+        local_full_path="cache_dir/20220101_000000Z/org-package1/main",
+    )
+    python_env_manager_mock = mocker.Mock()
+    python_env_manager_mock.get_environment.return_value = (
+        "cache_dir/20220101_000000Z/org_package1_virtualenv"
+    )
+    get_dependencies_mock = mocker.patch(
+        "dd_license_attribution.artifact_management.python_env_manager.PythonEnvManager.get_dependencies",
+        return_value=[
+            ("package_with_uppercase_homepage", "1.0.0"),
+            ("package_with_lowercase_github", "2.0.0"),
+            ("package_with_mixedcase_repository", "3.0.0"),
+            ("package_with_uppercase_source_code", "4.0.0"),
+        ],
+    )
+
+    mock_request = mocker.patch("requests.get")
+    mock_request.side_effect = [
+        # Test 1: HOMEPAGE in all caps
+        MockedRequestsResponse(
+            200,
+            {
+                "info": {
+                    "license": "MIT",
+                    "author": "Author A",
+                    "name": "package_with_uppercase_homepage",
+                    "version": "1.0.0",
+                    "project_urls": {
+                        "HOMEPAGE": "https://github.com/org/package_uppercase_homepage"
+                    },
+                }
+            },
+        ),
+        # Test 2: github in all lowercase
+        MockedRequestsResponse(
+            200,
+            {
+                "info": {
+                    "license": "Apache-2.0",
+                    "author": "Author B",
+                    "name": "package_with_lowercase_github",
+                    "version": "2.0.0",
+                    "project_urls": {
+                        "homepage": "not_a_valid_url",
+                        "github": "https://github.com/org/package_lowercase_github",
+                    },
+                }
+            },
+        ),
+        # Test 3: RePoSiToRy in mixed case
+        MockedRequestsResponse(
+            200,
+            {
+                "info": {
+                    "license": "BSD-3-Clause",
+                    "author": "Author C",
+                    "name": "package_with_mixedcase_repository",
+                    "version": "3.0.0",
+                    "project_urls": {
+                        "RePoSiToRy": "https://github.com/org/package_mixedcase_repo"
+                    },
+                }
+            },
+        ),
+        # Test 4: SOURCE CODE in all caps (tests multi-word key)
+        MockedRequestsResponse(
+            200,
+            {
+                "info": {
+                    "license": "GPL-3.0",
+                    "author": "Author D",
+                    "name": "package_with_uppercase_source_code",
+                    "version": "4.0.0",
+                    "project_urls": {
+                        "SOURCE CODE": "https://github.com/org/package_uppercase_source"
+                    },
+                }
+            },
+        ),
+    ]
+
+    strategy = PypiMetadataCollectionStrategy(
+        "github.com/org/package1",
+        source_code_manager_mock,
+        python_env_manager_mock,
+        ProjectScope.ALL,
+    )
+
+    initial_metadata = [
+        Metadata(
+            name="github.com/org/package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+
+    result = strategy.augment_metadata(initial_metadata)
+
+    # Verify that all packages were found and their GitHub URLs were extracted correctly
+    # despite different capitalizations of the project_urls keys
+    expected_metadata = [
+        Metadata(
+            name="github.com/org/package1",
+            origin="https://github.com/org/package1",
+            local_src_path="cache_dir/20220101_000000Z/org-package1/main",
+            version=None,
+            license=[],
+            copyright=[],
+        ),
+        Metadata(
+            name="package_with_uppercase_homepage",
+            origin="https://github.com/org/package_uppercase_homepage",
+            local_src_path=None,
+            version="1.0.0",
+            license=["MIT"],
+            copyright=["Author A"],
+        ),
+        Metadata(
+            name="package_with_lowercase_github",
+            origin="https://github.com/org/package_lowercase_github",
+            local_src_path=None,
+            version="2.0.0",
+            license=["Apache-2.0"],
+            copyright=["Author B"],
+        ),
+        Metadata(
+            name="package_with_mixedcase_repository",
+            origin="https://github.com/org/package_mixedcase_repo",
+            local_src_path=None,
+            version="3.0.0",
+            license=["BSD-3-Clause"],
+            copyright=["Author C"],
+        ),
+        Metadata(
+            name="package_with_uppercase_source_code",
+            origin="https://github.com/org/package_uppercase_source",
+            local_src_path=None,
+            version="4.0.0",
+            license=["GPL-3.0"],
+            copyright=["Author D"],
+        ),
+    ]
+
+    assert result == expected_metadata
+
+    # Verify all mocks were called correctly
+    source_code_manager_mock.get_code.assert_called_once_with(
+        "https://github.com/org/package1"
+    )
+    python_env_manager_mock.get_environment.assert_called_once_with(
+        "cache_dir/20220101_000000Z/org-package1/main"
+    )
+    get_dependencies_mock.assert_called_once_with(
+        "cache_dir/20220101_000000Z/org_package1_virtualenv"
+    )
+    assert mock_request.call_count == 4
+    mock_request.assert_has_calls(
+        [
+            mocker.call(
+                "https://pypi.org/pypi/package_with_uppercase_homepage/1.0.0/json"
+            ),
+            mocker.call(
+                "https://pypi.org/pypi/package_with_lowercase_github/2.0.0/json"
+            ),
+            mocker.call(
+                "https://pypi.org/pypi/package_with_mixedcase_repository/3.0.0/json"
+            ),
+            mocker.call(
+                "https://pypi.org/pypi/package_with_uppercase_source_code/4.0.0/json"
+            ),
+        ]
+    )


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

We were missing some available git sources in PyPI because we were looking for case sensitive keys, and some of them were under case insensitive ones (i.e. `Repository` vs `repository`).

This PR changes the comparison, so it looks for the relevant project_urls with a case insensitive key.

