### PR TITLE
Add support for multiple yarn.lock files in subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for GitHub renamed/transferred repositories
 - Support for Yarn package manager in npm collection
+- New `--yarn-subdir` CLI option for specifying subdirectories with additional `yarn.lock` files in monorepos
 
 ### Changed
 - PyPI collection strategy now performs case-insensitive key matching for project_urls dictionary to better handle different key capitalizations from PyPI metadata

--- a/src/dd_license_attribution/cli/generate_sbom_csv_command.py
+++ b/src/dd_license_attribution/cli/generate_sbom_csv_command.py
@@ -335,6 +335,14 @@ def generate_sbom_csv(
             help="Path to a JSON file containing mirror specifications for repositories."
         ),
     ] = None,
+    yarn_subdirs: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--yarn-subdir",
+            help="Subdirectory path(s) containing additional yarn.lock files to include in dependency analysis. Can be specified multiple times. Paths are relative to repository root.",
+            rich_help_panel="Scanning Options",
+        ),
+    ] = None,
 ) -> None:
     """
     Generate a CSV report (SBOM) of third party dependencies for a given
@@ -462,6 +470,7 @@ def generate_sbom_csv(
                 package,
                 source_code_manager,
                 project_scope,
+                yarn_subdirs=yarn_subdirs or [],
             )
         )
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Allow users to specify subdirectories containing additional yarn.lock files when generating SBOMs, enabling dependency collection from monorepos or projects with multiple yarn workspaces.

Changes:
- Add `--yarn-subdir` CLI option (repeatable) to specify subdirectory paths relative to repository root

Example usage:

```
dd-license-attribution generate-sbom-csv \
  --yarn-subdir packages/dd-trace \
  --yarn-subdir packages/another \
  https://github.com/datadog/dd-trace-js > LICENSE-3rdparty.csv
```

Backward compatible: works without the new option (defaults to root only).

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
