### PR TITLE
fix: use resolved versions from package-lock.json instead of semver ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - PyPI collection strategy now performs case-insensitive key matching for project_urls dictionary to better handle different key capitalizations from PyPI metadata
 
+### Fixed
+- Fixed npm metadata collection using semver ranges instead of resolved versions, causing incorrect or failed npm registry API lookups
+
 ## [0.5.0] - 2025-10-29
 
 ### Added


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

Previously, the npm collection strategy extracted version information from the `dependencies` field in `package-lock.json`, which contains semver range specifiers (e.g., `^1.2.3`, `>=1.0.0 <2.0.0`). This caused issues when fetching metadata from the npm registry API, which requires exact version numbers.

The code attempted to clean these ranges with `_clean_version_string()` by stripping simple prefixes (`^`, `~`, `>=`, `>`), but this approach had critical flaws:
- Failed completely on ranges like `<=1.2.3` (`<` prefix not handled)
- Failed completely on compound ranges like `>=1.2.3 <1.5.0` (space-separated ranges not supported)
- Even when it worked, it was fundamentally incorrect - a range like `^1.2.3` could resolve to any version from `1.2.3` to `<2.0.0`, so using `1.2.3` could fetch metadata for the wrong version

Changes:
- Modified `_get_npm_dependencies()` to read resolved versions from the `version` field in `node_modules` entries instead of ranges from `dependencies` field
- Modified `_extract_transitive_dependencies()` to use the same approach for transitive dependencies
- Removed `_clean_version_string()` function as it's no longer needed
- Updated existing tests to use realistic semver ranges with different resolved versions to verify the fix
- Added `test_npm_handles_complex_semver_ranges()` to verify complex ranges like `>=1.0.0 <2.0.0`, `<1.5.0`, and `1.0.0 - 2.0.0` work correctly
- Added `test_npm_handles_missing_node_modules_entry()` to verify graceful handling of missing dependencies with appropriate warnings

Fixes incorrect or failed npm registry API lookups that occurred when dependencies had complex or unsupported semver ranges, or when the resolved version differed from the range's lower bound.

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
