### PR TITLE
fix: set explicit CSV line endings for cross-version consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed npm metadata collection using semver ranges instead of resolved versions, causing incorrect or failed npm registry API lookups
+- Fixed CSV output to use consistent Windows-style line endings (`\r\n`) across all platforms and Python versions, preventing line ending inconsistencies between different Python versions
 
 ## [0.5.0] - 2025-10-29
 

--- a/src/dd_license_attribution/report_generator/writters/csv_reporting_writter.py
+++ b/src/dd_license_attribution/report_generator/writters/csv_reporting_writter.py
@@ -31,7 +31,9 @@ class CSVReportingWritter(ReportingWritter):
 
         field_names = ["component", "origin", "license", "copyright"]
         output = io.StringIO()
-        writer = csv.DictWriter(output, fieldnames=field_names, quoting=csv.QUOTE_ALL)
+        writer = csv.DictWriter(
+            output, fieldnames=field_names, quoting=csv.QUOTE_ALL, lineterminator="\r\n"
+        )
 
         writer.writeheader()
         combined_metadata: dict[tuple[str | None, str | None], RowOfData] = {}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR fixes CSV output inconsistencies caused by different Python versions. Python 3.14 changed the `csv` module's default line terminator behavior to use system-native line endings (e.g., `\n` on Unix systems), while Python 3.12 and earlier always used `\r\n` regardless of platform.

Without explicitly setting the line terminator, the tool produces different output depending on the Python version:
- **Python 3.12 (local macOS)**: Uses `\r\n` (Windows-style line endings)
- **Python 3.14 (CI Ubuntu)**: Uses `\n` (Unix-style line endings)

This PR explicitly sets `lineterminator="\r\n"` in the CSV writer to ensure consistent output across all Python versions and platforms, maintaining backwards compatibility with existing LICENSE-3rdparty.csv files.

**Changes:**
- Updated `CSVReportingWritter` to explicitly specify `lineterminator="\r\n"`
- Updated tests to verify `\r\n` line endings
- Updated CHANGELOG

## Related tickets & Documents

- Related Issue #
- Closes #

## How to reproduce and testing

**To reproduce the issue:**

1. Generate a CSV file on macOS with Python 3.12.9:
   dd-license-attribution generate-sbom-csv <REPO_URL> > output-local.csv
   2. Generate the same CSV file on Ubuntu with Python 3.14.2:
   dd-license-attribution generate-sbom-csv <REPO_URL> > output-ci.csv
   3. Compare line endings:
   od -c output-local.csv | head -5   # Shows \r\n
   od -c output-ci.csv | head -5       # Shows \n (before fix)
   **Testing:**
- ✅ Unit tests pass on Python 3.12.9
- ✅ Verified CSV output uses `\r\n` line endings consistently
- ✅ MyPy type checking passes
- ✅ Black formatting passes
- ✅ Backwards compatible with existing LICENSE-3rdparty.csv files

**Tested on:**
- macOS 24.6.0 with Python 3.12.9
- Expected to work on Ubuntu 24.04 with Python 3.14.2 (CI will verify)