### PR TITLE
Do not split full license text with commas

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -62,7 +62,7 @@
 "pygmars","https://github.com/aboutcode-org/pygmars","['Apache-2.0']","['nexB. Inc. and others']"
 "pyicu","https://gitlab.pyicu.org/main/pyicu","['MIT']","['Andi Vajda']"
 "pymaven-patch","https://github.com/aboutcode-org/pymaven","['Apache-2']","['Walter Scheper']"
-"pyparsing","https://github.com/pyparsing/pyparsing","['MIT']","['pyparsing']"
+"pyparsing","https://github.com/pyparsing/pyparsing","['MIT']","['Paul McGuire']"
 "pytz","https://pythonhosted.org/pytz","['MIT']","['Stuart Bishop']"
 "rdflib","https://github.com/RDFLib/rdflib","['BSD-3-Clause']","[""Daniel 'eikeon' Krech""]"
 "requests","https://github.com/psf/requests","['Apache-2.0']","['Kenneth Reitz']"

--- a/src/dd_license_attribution/metadata_collector/strategies/pypi_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/pypi_collection_strategy.py
@@ -27,6 +27,7 @@ from dd_license_attribution.metadata_collector.strategies.abstract_collection_st
     MetadataCollectionStrategy,
 )
 from dd_license_attribution.utils.custom_splitting import CustomSplit
+from dd_license_attribution.utils.license_utils import is_long_license
 
 
 class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
@@ -147,7 +148,12 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
                     and pypi_info["license"] is not None
                     and len(pypi_info["license"]) != 0
                 ):
-                    find_pkg.license = pypi_info["license"].split(",")
+                    # Only split on commas if it's not a long license text
+                    # Long licenses (full text with newlines) should not be split
+                    if is_long_license(pypi_info["license"]):
+                        find_pkg.license = [pypi_info["license"]]
+                    else:
+                        find_pkg.license = pypi_info["license"].split(",")
                 if "version" in pypi_info and pypi_info["version"] is not None:
                     find_pkg.version = pypi_info["version"]
                 if (
@@ -166,7 +172,12 @@ class PypiMetadataCollectionStrategy(MetadataCollectionStrategy):
                     and pypi_info["license"] is not None
                     and len(pypi_info["license"]) != 0
                 ):
-                    extracted_license = pypi_info["license"].split(",")
+                    # Only split on commas if it's not a long license text
+                    # Long licenses (full text with newlines) should not be split
+                    if is_long_license(pypi_info["license"]):
+                        extracted_license = [pypi_info["license"]]
+                    else:
+                        extracted_license = pypi_info["license"].split(",")
                 extracted_copyright = []
                 if (
                     "author" in pypi_info

--- a/src/dd_license_attribution/utils/license_utils.py
+++ b/src/dd_license_attribution/utils/license_utils.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+# Utility functions for license text processing
+
+
+def is_long_license(license_text: str) -> bool:
+    """
+    Check if a license text is a long description that should not be split or processed as a simple identifier.
+
+    Long licenses typically contain the full license text rather than just an SPDX identifier.
+    This helps distinguish between:
+    - Short SPDX identifiers: "MIT", "BSD-3-Clause", "Apache-2.0"
+    - Long license text: Full license content with newlines and extensive text
+
+    Args:
+        license_text: The license text to check
+
+    Returns:
+        True if the license text is long (contains newlines or is longer than 50 characters),
+        False if it appears to be a short SPDX identifier
+    """
+    # Consider it long if it has newlines or is longer than 50 characters
+    # (typical SPDX IDs are short like "MIT", "BSD-3-Clause", "Apache-2.0")
+    return "\n" in license_text or len(license_text) > 50

--- a/src/dd_license_attribution/utils/license_utils.py
+++ b/src/dd_license_attribution/utils/license_utils.py
@@ -3,7 +3,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 #
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2025-present Datadog, Inc.
+# Copyright 2026-present Datadog, Inc.
 
 # Utility functions for license text processing
 

--- a/tests/unit/test_license_utils.py
+++ b/tests/unit/test_license_utils.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+# Unit tests for license utilities
+
+from dd_license_attribution.utils.license_utils import is_long_license
+
+
+class TestIsLongLicense:
+    """Test is_long_license utility function."""
+
+    def test_is_long_license_with_newlines(self) -> None:
+        """Test is_long_license with license containing newlines."""
+        license_with_newlines = "MIT License\n\nCopyright 2024"
+        assert is_long_license(license_with_newlines) is True
+
+    def test_is_long_license_with_long_text(self) -> None:
+        """Test is_long_license with long text (>50 chars)."""
+        long_text = (
+            "This is a very long license description that exceeds fifty characters"
+        )
+        assert is_long_license(long_text) is True
+
+    def test_is_long_license_with_spdx_identifier(self) -> None:
+        """Test is_long_license with short SPDX identifiers."""
+        assert is_long_license("MIT") is False
+        assert is_long_license("BSD-3-Clause") is False
+        assert is_long_license("Apache-2.0") is False
+        assert is_long_license("GPL-3.0-or-later") is False
+
+    def test_is_long_license_with_empty_string(self) -> None:
+        """Test is_long_license with empty string."""
+        assert is_long_license("") is False
+
+    def test_is_long_license_at_boundary(self) -> None:
+        """Test is_long_license at exactly 50 characters."""
+        exactly_50_chars = "a" * 50
+        assert is_long_license(exactly_50_chars) is False
+
+        just_over_50_chars = "a" * 51
+        assert is_long_license(just_over_50_chars) is True
+
+    def test_is_long_license_with_full_bsd_license(self) -> None:
+        """Test is_long_license with full BSD license text."""
+        full_license = """BSD 3-Clause License
+
+Copyright (c) 2022, Jupyter
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+"""
+        assert is_long_license(full_license) is True
+
+    def test_is_long_license_with_comma_separated_licenses(self) -> None:
+        """Test is_long_license with comma-separated SPDX identifiers."""
+        # These should not be considered long licenses
+        assert is_long_license("MIT, Apache-2.0") is False
+        assert is_long_license("BSD-3-Clause, GPL-2.0") is False


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature / Major Change / Refactor / Optimization
- [x] Bug Fix
- [ ] Documentation Update

## Description

PyPI accepts the full license text for the license field. In those cases (where we suspect is the full license and not an identifier), we shouldn't split by comma.
