### PR TITLE
Add claude support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,7 @@ cython_debug/
 !.cursor/rules/*
 .cursor/
 
+# Claude Code
+.claude
+
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
NO-OP

Add .claude local config folder to .gitignore and symlink `CLAUDE.md` to the existing `AGENTS.md`

The test failure is fixed in this other PR: https://github.com/DataDog/dd-license-attribution/pull/169