### PR TITLE
Ignore invalid API key tests for OpenAI and Anthropic

### DIFF
--- a/tests/contract/test_llm_apis.py
+++ b/tests/contract/test_llm_apis.py
@@ -81,7 +81,7 @@ class TestOpenAIAPIContract:
 
         We depend on catching openai.AuthenticationError for invalid credentials.
         """
-        invalid_client = openai.OpenAI(api_key="invalid_key_12345")
+        invalid_client = openai.OpenAI(api_key="invalid_key_12345") # dd-oss: ignore
 
         with pytest.raises(openai.AuthenticationError) as exc_info:
             invalid_client.chat.completions.create(
@@ -220,7 +220,7 @@ class TestAnthropicAPIContract:
 
         We depend on catching anthropic.AuthenticationError for invalid credentials.
         """
-        invalid_client = anthropic.Anthropic(api_key="invalid_key_12345")
+        invalid_client = anthropic.Anthropic(api_key="invalid_key_12345") # dd-oss: ignore
 
         with pytest.raises(anthropic.AuthenticationError) as exc_info:
             invalid_client.messages.create(


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the project's contributing guide
     - 👷‍♀️ Create small PRs.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [ ] Bug Fix
- [x] Documentation Update

## Description

When running secret scanners on the repository, a api-key used in mocked test triggered the scanner as a valid key. Adding a marker to silence the alert in this case, since it is clearly a fake test only key.

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
