### PR TITLE
Fix libicu macOS install instructions

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -12,7 +12,7 @@
 "banal","https://github.com/pudo/banal","['MIT']","['Friedrich Lindenberg']"
 "beartype","https://github.com/beartype/beartype","['MIT']","['Beartype authors']"
 "beautifulsoup4","https://www.crummy.com/software/BeautifulSoup/bs4/","['MIT']","['Leonard Richardson']"
-"binaryornot","https://github.com/binaryornot/binaryornot","['BSD']","['Audrey Roy Greenfeld']"
+"binaryornot","https://github.com/binaryornot/binaryornot","['MIT']","['Audrey Roy Greenfeld']"
 "boolean.py","https://github.com/bastikr/boolean.py","['BSD-2-Clause']","['Sebastian Kraemer']"
 "certifi","https://github.com/certifi/python-certifi","['MPL-2.0']","['Kenneth Reitz']"
 "cffi","https://github.com/python-cffi/cffi","['MIT-0']","['Armin Rigo', 'Maciej Fijalkowski']"

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Run `dd-license-attribution --help` to see all available commands.
 - python3.11+ - [Python install instructions](https://www.python.org/downloads/)
 - libmagic (only on MacOS):
   - `brew install libmagic`
-- libuci (only on MacOS)
-  - `brew install icu4c && brew link icu4c --force`
+- libicu (only on macOS):
+  - `brew install icu4c pkg-config`
+  - Add the following line to your `~/.zshrc` or `~/.bashrc`: `export PKG_CONFIG_PATH="$(brew --prefix icu4c)/lib/pkgconfig"`
 
 #### Optional Requirements
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Run `dd-license-attribution --help` to see all available commands.
   - `brew install libmagic`
 - libicu (only on macOS):
   - `brew install icu4c pkg-config`
-  - Add the following line to your `~/.zshrc` or `~/.bashrc`: `export PKG_CONFIG_PATH="$(brew --prefix icu4c)/lib/pkgconfig"`
+  - Add the following line to your `~/.zshrc` or `~/.bashrc`: `export PKG_CONFIG_PATH="$(brew --prefix icu4c)/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"`
 
 #### Optional Requirements
 


### PR DESCRIPTION
## Summary
- Fix typo `libuci` → `libicu` in the Requirements section
- Replace unreliable `brew link icu4c --force` (fails on modern macOS/Homebrew since `icu4c` is keg-only) with the `PKG_CONFIG_PATH` approach
- Suggest adding the export to the shell profile since it must be set every session

## Test plan
- [x] Verify `pip install .` works on macOS after following the updated instructions

Fixes #181