### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                         @DataDog/ospo
+*                         @DataDog/open-source-program-office

--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,5 +1,7 @@
----
 schema-version: v1
-kind: mergequeue
-enable: true
-merge_method: rebase
+kind: mergegate
+name: mergegate-ospo
+rules:
+  - require: commit-signatures
+  - require: all-files-are-owned
+  - require: reviewers-approval


### PR DESCRIPTION
This PR:

* Updates codeowners to the official team name
* Disables mergequeue, as we don't really use it
* Enables mergegate