### PR TITLE
chore(ci): improvements to CI practices

### DIFF
--- a/.github/workflows/coverage-regression.yml
+++ b/.github/workflows/coverage-regression.yml
@@ -33,15 +33,18 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run coverage on target branch
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git checkout ${{ github.event.pull_request.base.sha }}
+          git checkout "${PR_BASE_SHA}"
           pip install -e "." --quiet
           pytest tests/unit/ --cov=src/dd_license_attribution --cov-report=xml:coverage-base.xml -q || true
           if [ ! -f coverage-base.xml ]; then
             echo "::warning::Failed to collect coverage on target branch. Skipping regression check."
             echo "SKIP_REGRESSION=true" >> "$GITHUB_ENV"
           fi
-          git checkout ${{ github.event.pull_request.head.sha }}
+          git checkout "${PR_HEAD_SHA}"
           pip install -e "." --quiet
 
       - name: Run coverage on PR branch
@@ -50,8 +53,12 @@ jobs:
 
       - name: Compare coverage and detect regressions
         if: env.SKIP_REGRESSION != 'true'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           python3 << 'SCRIPT'
+          import os
           import xml.etree.ElementTree as ET
           import subprocess
           import sys
@@ -77,8 +84,8 @@ jobs:
 
           def get_modified_files():
               """Get set of files modified in the PR."""
-              base_sha = "${{ github.event.pull_request.base.sha }}"
-              head_sha = "${{ github.event.pull_request.head.sha }}"
+              base_sha = os.environ["PR_BASE_SHA"]
+              head_sha = os.environ["PR_HEAD_SHA"]
               result = subprocess.run(
                   ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
                   capture_output=True, text=True

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,13 +53,17 @@ jobs:
       - name: Run the dd-license-attribution script against the dd-license-attribution repository with overrides
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           # For PRs: Use mirror configuration to test against the PR branch
           # For main: Test against main branch directly (no mirror needed)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH_NAME="${{ github.head_ref }}"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            BRANCH_NAME="${HEAD_REF}"
             # Use head repo so fork PRs clone the branch from the fork, not upstream
-            MIRROR_URL="https://github.com/${{ github.event.pull_request.head.repo.full_name }}"
+            MIRROR_URL="https://github.com/${PR_HEAD_REPO}"
             echo "Testing PR branch: ${BRANCH_NAME}"
             echo "[{\"original_url\": \"https://github.com/DataDog/dd-license-attribution\", \"mirror_url\": \"${MIRROR_URL}\", \"ref_mapping\": {\"branch:main\": \"branch:${BRANCH_NAME}\"}}]" > mirrors.json
             dd-license-attribution generate-sbom --override-spec=.ddla-overrides --use-mirrors=mirrors.json https://github.com/DataDog/dd-license-attribution > ddla-output.txt
@@ -71,7 +75,7 @@ jobs:
           # Only compare CSV output on the primary development version (3.14).
           # Dependency closures differ across Python versions (e.g., setuptools
           # appears on 3.11 but not 3.14), so exact comparison only works on one.
-          if [ "${{ matrix.python-version }}" = "3.14" ]; then
+          if [ "${PYTHON_VERSION}" = "3.14" ]; then
             if ! cmp -s LICENSE-3rdparty.csv ddla-output.txt; then
               echo "Error: LICENSE-3rdparty.csv differs from ddla-output.txt"
               echo "Diff between files:"
@@ -83,15 +87,16 @@ jobs:
             # On other versions, just validate the output is non-empty CSV with expected header
             head -1 ddla-output.txt | grep -iq "component.*origin.*license.*copyright"
             line_count=$(wc -l < ddla-output.txt)
-            echo "CSV comparison skipped on Python ${{ matrix.python-version }} (closure may differ). Output has $((line_count - 1)) dependencies."
+            echo "CSV comparison skipped on Python ${PYTHON_VERSION} (closure may differ). Output has $((line_count - 1)) dependencies."
           fi
 
       - name: Run the dd-license-attribution script with SPDX output
         if: ${{ matrix.python-version == '3.14' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
             dd-license-attribution generate-sbom --format spdx --use-mirrors=mirrors.json https://github.com/DataDog/dd-license-attribution > ddla-spdx-output.json
           else
             dd-license-attribution generate-sbom --format spdx https://github.com/DataDog/dd-license-attribution > ddla-spdx-output.json

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -54,8 +54,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
-          HEAD_REF: ${{ github.head_ref }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.head_ref || '' }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           # For PRs: Use mirror configuration to test against the PR branch

--- a/.github/workflows/mutation-regression.yml
+++ b/.github/workflows/mutation-regression.yml
@@ -26,19 +26,22 @@ jobs:
 
       - name: Detect changed mutatable source files
         id: changed-files
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          BASE=${{ github.event.pull_request.base.sha }}
-          HEAD=${{ github.event.pull_request.head.sha }}
+          BASE="${PR_BASE_SHA}"
+          HEAD="${PR_HEAD_SHA}"
 
           # Source files changed directly
-          SRC_FILES=$(git diff --name-only "$BASE" "$HEAD" \
+          SRC_FILES=$(git diff --name-only "${BASE}" "${HEAD}" \
             | grep '^src/dd_license_attribution/.*\.py$' \
             | grep -v '/cli/' \
             | grep -v '/adaptors/' \
             | grep -v '/config/') || true
 
           # Source files corresponding to changed test files (test_X.py -> X.py)
-          TEST_DERIVED=$(git diff --name-only "$BASE" "$HEAD" \
+          TEST_DERIVED=$(git diff --name-only "${BASE}" "${HEAD}" \
             | grep '^tests/unit/test_.*\.py$' \
             | sed 's|tests/unit/test_||' \
             | while IFS= read -r basename; do
@@ -74,13 +77,18 @@ jobs:
 
       - name: Run mutation testing on target branch
         if: steps.changed-files.outputs.paths != ''
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHANGED_PATHS: ${{ steps.changed-files.outputs.paths }}
         run: |
-          git checkout ${{ github.event.pull_request.base.sha }}
+          git checkout "${PR_BASE_SHA}"
           pip install -e "." --quiet
           python3 << 'PYEOF'
+          import os
           import re
           content = open('pyproject.toml').read()
-          paths = "${{ steps.changed-files.outputs.paths }}".split(',')
+          paths = os.environ['CHANGED_PATHS'].split(',')
           paths_str = '[' + ', '.join('"' + p.strip() + '"' for p in paths) + ']'
           content = re.sub(r'paths_to_mutate = \[.*\]', 'paths_to_mutate = ' + paths_str, content)
           # also_copy ensures the full src/ tree is in mutants/ so imports work when
@@ -94,16 +102,19 @@ jobs:
           mutmut results --all true > mutmut-base-results.txt
           rm -rf mutants/ .mutmut-cache
           git checkout -- pyproject.toml
-          git checkout ${{ github.event.pull_request.head.sha }}
+          git checkout "${PR_HEAD_SHA}"
           pip install -e "." --quiet
 
       - name: Run mutation testing on PR branch
         if: steps.changed-files.outputs.paths != ''
+        env:
+          CHANGED_PATHS: ${{ steps.changed-files.outputs.paths }}
         run: |
           python3 << 'PYEOF'
+          import os
           import re
           content = open('pyproject.toml').read()
-          paths = "${{ steps.changed-files.outputs.paths }}".split(',')
+          paths = os.environ['CHANGED_PATHS'].split(',')
           paths_str = '[' + ', '.join('"' + p.strip() + '"' for p in paths) + ']'
           content = re.sub(r'paths_to_mutate = \[.*\]', 'paths_to_mutate = ' + paths_str, content)
           if 'also_copy' not in content:


### PR DESCRIPTION
Move user-controlled GitHub Actions context expressions out of `run:` blocks and into `env:` variables across all CI workflow files, preventing shell injection via branch names or PR metadata.