### PR TITLE
Add Markdown SBOM output and multi-format report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - New `--experimental-strategy` flag for `generate-sbom`. When enabled, dependency discovery and metadata extraction run in three phases: pre-finders run once on the root package (e.g. GitHub SBOM, which already returns a full transitive closure); finders run in a fixpoint loop (up to 5 iterations) until the dependency set stabilises; enrichers run once on the complete set. When combined with `--ecosystem`, only the ecosystem-relevant finder is enabled by default; `--no-*` flags still override these defaults. This resolves cases where transitive dependencies discovered by one finder were not explored by other finders.
+- New `markdown` value for `generate-sbom --format` to emit Markdown license compliance reports.
+- New repeatable `generate-sbom --format` support with `--output-dir` to emit CSV, Markdown, and SPDX report files in one run.
 - New `generate-sbom` subcommand with a `--format` option supporting CSV output by default and SPDX 2.3 JSON output via `--format spdx`.
 - `generate-sbom-csv` now emits a WARNING for each package whose license value is not a properly written SPDX expression composed entirely of OSI-approved identifiers. Using a non-OSI-approved license may be acceptable depending on your project's requirements. The warning message includes a reference to `generate-overrides` (interactive) and `clean-spdx-id` (AI-assisted) as remediation options.
 - Add `--ecosystem go` support for direct Go package/module dependency analysis (e.g., `ddla generate-sbom-csv --ecosystem go github.com/stretchr/testify@v1.9.0`)
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New `clean-spdx-id` CLI command to convert long license descriptions to valid SPDX license expressions using LLMs (OpenAI, Anthropic), including support for composite licenses (e.g., "MIT OR Apache-2.0")
 
 ### Changed
+- Markdown `generate-sbom` reports now show the root package version explicitly, exclude the root package from the dependency table, and include root license and copyright in the summary.
 - PyPI collection strategy now performs case-insensitive key matching for project_urls dictionary to better handle different key capitalizations from PyPI metadata
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `generate-sbom-csv` is deprecated in favor of `generate-sbom --format csv`; it still works and emits a deprecation warning.
 
 ### Fixed
+- Fixed `generate-sbom --no-gh-auth` so it ignores a `GITHUB_TOKEN` environment variable instead of using a potentially invalid token.
 - Fixed npm ecosystem SBOM generation when `npm list --json` emits warnings on stderr, which previously caused empty CSV output for packages such as `dd-trace`.
 - Fixed npm metadata collection using semver ranges instead of resolved versions, causing incorrect or failed npm registry API lookups
 - Fixed support for package aliases in both Yarn and npm projects (e.g., `"@datadog/source-map": "npm:source-map@^0.6.0"`). The tool now parses both yarn.lock and package-lock.json files to resolve aliases to their real package names before fetching npm registry metadata, eliminating 404 errors for aliased packages

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For more advanced usage, see the sections below.
 
 `dd-license-attribution` provides the following commands:
 
-1. **`generate-sbom`** - Generate an SBOM of third-party dependencies as CSV or SPDX 2.3 JSON
+1. **`generate-sbom`** - Generate an SBOM of third-party dependencies as CSV, Markdown, or SPDX 2.3 JSON
 2. **`generate-overrides`** - Interactively generate override configuration files
 3. **`clean-spdx-id`** - Convert long license descriptions to valid SPDX license expressions using AI
 
@@ -91,6 +91,12 @@ dd-license-attribution generate-sbom https://github.com/owner/repo > LICENSE-3rd
 
 # Emit SPDX 2.3 JSON instead of CSV
 dd-license-attribution generate-sbom https://github.com/owner/repo --format spdx > sbom.spdx.json
+
+# Emit a Markdown license compliance report instead of CSV
+dd-license-attribution generate-sbom https://github.com/owner/repo --format markdown > LICENSE-3rdparty.md
+
+# Emit multiple formats from a single metadata collection run
+dd-license-attribution generate-sbom https://github.com/owner/repo --format csv --format markdown --format spdx --output-dir ./reports
 ```
 
 The following optional parameters are available for `generate-sbom`:
@@ -134,7 +140,8 @@ The following optional parameters are available for `generate-sbom`:
   > **Note**: This flag gates experimental behavior that is not yet stable. The strategy classification (pre-finder vs. finder vs. enricher) may change as the feature matures.
 
 #### Output Options
-- `--format <csv|spdx>`: Selects the SBOM output format. Defaults to `csv`; `spdx` emits SPDX 2.3 JSON.
+- `--format <csv|spdx|markdown>`: Selects the SBOM output format. Defaults to `csv`. Repeat this option to request multiple formats in one run, for example `--format csv --format markdown --format spdx`.
+- `--output-dir <path>`: Writes one file per requested format into the directory instead of writing the report to stdout. The directory is created if it does not exist. This option is required when passing multiple `--format` values. Generated file extensions are `.csv` for CSV, `.md` for Markdown, and `.json` for SPDX.
 
 #### Cache Configuration
 
@@ -143,9 +150,15 @@ The following optional parameters are available for `generate-sbom`:
 
 For more details about optional parameters pass `--help` to the command.
 
-#### Output Format
+#### Output Formats
 
-The tool generates a CSV file with the following columns:
+By default, `generate-sbom` writes a CSV report to stdout so it can be redirected to a file:
+
+```bash
+dd-license-attribution generate-sbom https://github.com/owner/repo > LICENSE-3rdparty.csv
+```
+
+CSV reports contain the following columns:
 - `Component`: The name of the dependency
 - `Origin`: The source URL of the dependency
 - `License`: The detected license(s)
@@ -157,6 +170,28 @@ Component,Origin,License,Copyright
 aiohttp,https://github.com/aio-libs/aiohttp,Apache-2.0,"aio-libs"
 requests,https://github.com/psf/requests,Apache-2.0,"Kenneth Reitz"
 ```
+
+Markdown reports can be generated with `--format markdown`:
+
+```bash
+dd-license-attribution generate-sbom https://github.com/owner/repo --format markdown > LICENSE-3rdparty.md
+```
+
+Markdown reports include a root package summary followed by a third-party dependency table. The root package is summarized separately and excluded from the dependency table.
+
+SPDX 2.3 JSON reports can be generated with `--format spdx`:
+
+```bash
+dd-license-attribution generate-sbom https://github.com/owner/repo --format spdx > sbom.spdx.json
+```
+
+To write more than one report format from the same metadata collection run, repeat `--format` and pass `--output-dir`:
+
+```bash
+dd-license-attribution generate-sbom https://github.com/owner/repo --format csv --format markdown --format spdx --output-dir ./reports
+```
+
+For a package such as `https://github.com/owner/repo`, this writes `github.com_owner_repo.csv`, `github.com_owner_repo.md`, and `github.com_owner_repo.json` under `./reports`.
 
 #### Output string configuration
 

--- a/src/dd_license_attribution/cli/generate_sbom_command.py
+++ b/src/dd_license_attribution/cli/generate_sbom_command.py
@@ -470,7 +470,7 @@ def generate_sbom(
         )
         output_formats = ["csv"]
 
-    requested_output_formats = output_formats or ["csv"]
+    requested_output_formats = list(dict.fromkeys(output_formats or ["csv"]))
 
     supported_output_formats = {"csv", "spdx", "markdown"}
     for requested_output_format in requested_output_formats:

--- a/src/dd_license_attribution/cli/generate_sbom_command.py
+++ b/src/dd_license_attribution/cli/generate_sbom_command.py
@@ -500,7 +500,7 @@ def generate_sbom(
         if skip_scancode:
             enabled_strategies["ScanCodeToolkitMetadataCollectionStrategy"] = False
 
-        if not github_token:
+        if no_gh_auth or not github_token:
             github_client = GitHub()
         else:
             github_client = GitHub(token=github_token)

--- a/src/dd_license_attribution/cli/generate_sbom_command.py
+++ b/src/dd_license_attribution/cli/generate_sbom_command.py
@@ -22,7 +22,12 @@ import typer
 from agithub.GitHub import GitHub
 
 import dd_license_attribution.config.cli_configs as cli_config
-from dd_license_attribution.adaptors.os import create_dirs, path_exists
+from dd_license_attribution.adaptors.os import (
+    create_dirs,
+    path_exists,
+    path_join,
+    write_file,
+)
 from dd_license_attribution.artifact_management.artifact_manager import (
     validate_cache_dir,
 )
@@ -85,6 +90,9 @@ from dd_license_attribution.report_generator.writters.abstract_reporting_writter
 from dd_license_attribution.report_generator.writters.csv_reporting_writter import (
     CSVReportingWritter,
 )
+from dd_license_attribution.report_generator.writters.markdown_reporting_writter import (
+    MarkdownReportingWritter,
+)
 from dd_license_attribution.report_generator.writters.spdx_reporting_writter import (
     SPDXReportingWritter,
 )
@@ -92,6 +100,40 @@ from dd_license_attribution.utils.logging import setup_logging
 
 # Get application-specific logger
 logger = logging.getLogger("dd_license_attribution")
+
+_OUTPUT_EXTENSIONS = {"csv": "csv", "spdx": "json", "markdown": "md"}
+_RESERVED_FILENAME_CHARS = '<>:"/\\|?*'
+
+
+def _report_document_name(package: str) -> str:
+    return package.replace("https://", "").replace("http://", "")
+
+
+def _report_output_base(package: str) -> str:
+    base = "".join(
+        "_" if char in _RESERVED_FILENAME_CHARS or ord(char) < 32 else char
+        for char in _report_document_name(package)
+    ).strip(" .")
+    if base:
+        return base
+    return "sbom"
+
+
+def _build_writer(
+    output_format: str, package: str, ecosystem: str | None
+) -> ReportingWritter:
+    if output_format == "csv":
+        return CSVReportingWritter()
+
+    document_name = _report_document_name(package)
+    if output_format == "spdx":
+        return SPDXReportingWritter(document_name=document_name)
+    if output_format == "markdown":
+        return MarkdownReportingWritter(
+            document_name=document_name, ecosystem=ecosystem
+        )
+
+    raise ValueError(f"Unsupported output format: {output_format}")
 
 
 def mutually_exclusive_group() -> (
@@ -385,14 +427,22 @@ def generate_sbom(
             rich_help_panel="Scanning Options",
         ),
     ] = None,
-    output_format: Annotated[
-        str,
+    output_formats: Annotated[
+        list[str] | None,
         typer.Option(
             "--format",
-            help="Output format. One of: csv, spdx (SPDX 2.3 JSON). Default: csv.",
+            help="Output format(s). Repeatable. One of: csv, spdx, markdown. Default: csv.",
             rich_help_panel="Output Options",
         ),
-    ] = "csv",
+    ] = None,
+    output_dir: Annotated[
+        str | None,
+        typer.Option(
+            "--output-dir",
+            help="Write one file per --format into this directory instead of stdout. Created if missing.",
+            rich_help_panel="Output Options",
+        ),
+    ] = None,
 ) -> None:
     """
     Generate an SBOM report of third party dependencies for a given
@@ -418,13 +468,19 @@ def generate_sbom(
         logger.warning(
             "generate-sbom-csv is deprecated; use generate-sbom --format csv instead."
         )
-        output_format = "csv"
+        output_formats = ["csv"]
 
-    supported_output_formats = {"csv", "spdx"}
-    if output_format not in supported_output_formats:
-        raise typer.BadParameter(
-            f"Unsupported output format: '{output_format}'. Supported formats: {', '.join(sorted(supported_output_formats))}."
-        )
+    requested_output_formats = output_formats or ["csv"]
+
+    supported_output_formats = {"csv", "spdx", "markdown"}
+    for requested_output_format in requested_output_formats:
+        if requested_output_format not in supported_output_formats:
+            raise typer.BadParameter(
+                f"Unsupported output format: '{requested_output_format}'. Supported formats: {', '.join(sorted(supported_output_formats))}."
+            )
+
+    if output_dir is None and len(requested_output_formats) > 1:
+        raise typer.BadParameter("Multiple --format values require --output-dir.")
 
     supported_ecosystems = ["npm", "python", "pypi", "go"]
     if ecosystem is not None and ecosystem not in supported_ecosystems:
@@ -771,15 +827,6 @@ def generate_sbom(
             )
             sys.exit(1)
 
-        reporting_writter: ReportingWritter
-        if output_format == "spdx":
-            reporting_writter = SPDXReportingWritter(
-                document_name=package.replace("https://", "").replace("http://", "")
-            )
-        else:
-            reporting_writter = CSVReportingWritter()
-        reporter = ReportGenerator(reporting_writter)
-
         checker = LicenseChecker(
             cli_config.default_config.preset_cautionary_licenses,
             cli_config.default_config.recognized_licenses,
@@ -787,11 +834,33 @@ def generate_sbom(
         checker.check_cautionary_licenses(metadata)
         checker.check_spdx_ids(metadata)
 
-        output = reporter.generate_report(metadata)
+        if output_dir is None:
+            reporting_writter = _build_writer(
+                requested_output_formats[0], package, ecosystem
+            )
+            reporter = ReportGenerator(reporting_writter)
+            output = reporter.generate_report(metadata)
 
-    # Output report to STDOUT for piping/redirection (e.g., ddla generate-sbom URL > output.csv)
-    # This is intentional CLI output, not logging. Do not replace with logger.info()
-    print(output, end="")
+            # Output report to STDOUT for piping/redirection (e.g., ddla generate-sbom URL > output.csv)
+            # This is intentional CLI output, not logging. Do not replace with logger.info()
+            print(output, end="")
+        else:
+            create_dirs(output_dir)
+            report_base = _report_output_base(package)
+            for requested_output_format in requested_output_formats:
+                reporting_writter = _build_writer(
+                    requested_output_format, package, ecosystem
+                )
+                reporter = ReportGenerator(reporting_writter)
+                output = reporter.generate_report(metadata)
+                output_path = path_join(
+                    output_dir,
+                    f"{report_base}.{_OUTPUT_EXTENSIONS[requested_output_format]}",
+                )
+                write_file(output_path, output)
+                logger.info(
+                    "Wrote %s report to %s", requested_output_format, output_path
+                )
     if override_strategy is not None and len(override_strategy.unused_targets()) != 0:
         logger.warning("Not all targets in the override spec file were used.")
         logger.warning(
@@ -803,7 +872,8 @@ def generate_sbom(
 def generate_sbom_csv(**kwargs: Any) -> None:
     if kwargs.get("package") is None:
         raise click.MissingParameter(param=click.Argument(["package"]))
-    kwargs["output_format"] = "csv"
+    kwargs.pop("output_format", None)
+    kwargs["output_formats"] = ["csv"]
     generate_sbom(**kwargs)
 
 
@@ -812,7 +882,7 @@ def _generate_sbom_csv_signature() -> inspect.Signature:
     parameters = [
         _clone_signature_parameter(parameter)
         for parameter in signature.parameters.values()
-        if parameter.name != "output_format"
+        if parameter.name != "output_formats"
     ]
     return signature.replace(parameters=parameters)
 

--- a/src/dd_license_attribution/cli/generate_sbom_command.py
+++ b/src/dd_license_attribution/cli/generate_sbom_command.py
@@ -119,6 +119,12 @@ def _report_output_base(package: str) -> str:
     return "sbom"
 
 
+def _canonical_ecosystem(ecosystem: str | None) -> str | None:
+    if ecosystem == "python":
+        return "pypi"
+    return ecosystem
+
+
 def _build_writer(
     output_format: str, package: str, ecosystem: str | None
 ) -> ReportingWritter:
@@ -487,6 +493,7 @@ def generate_sbom(
         raise typer.BadParameter(
             f"Unsupported ecosystem: '{ecosystem}'. Supported ecosystems: {', '.join(supported_ecosystems)}."
         )
+    ecosystem = _canonical_ecosystem(ecosystem)
 
     if not only_root_project and not only_transitive_dependencies:
         project_scope = ProjectScope.ALL
@@ -656,7 +663,7 @@ def generate_sbom(
                         github_client, source_code_manager
                     )
                 )
-        elif ecosystem in ("python", "pypi"):
+        elif ecosystem == "pypi":
             # PyPI package mode: resolve the PyPI package and build pypi-specific pipeline
             pypi_temp_dir = cleanup_stack.enter_context(tempfile.TemporaryDirectory())
             pypi_resolver = PypiPackageResolver(pypi_temp_dir)

--- a/src/dd_license_attribution/report_generator/writters/markdown_reporting_writter.py
+++ b/src/dd_license_attribution/report_generator/writters/markdown_reporting_writter.py
@@ -5,6 +5,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2026-present Datadog, Inc.
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -17,6 +18,12 @@ from dd_license_attribution.report_generator.writters.abstract_reporting_writter
 from dd_license_attribution.report_generator.writters.metadata_combiner import (
     CombinedMetadata,
     combine_metadata,
+)
+
+_PYPI_SPEC_PATTERN = re.compile(
+    r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)"
+    r"(?:\[[A-Za-z0-9._,\-\s]+\])?"
+    r"\s*(?:(==|!=|<=|>=|~=|<|>)\s*([^,;\s]+).*)?$"
 )
 
 
@@ -53,7 +60,7 @@ class MarkdownReportingWritter(ReportingWritter):
             "",
             "| Field | Value |",
             "| --- | --- |",
-            f"| Package | {_markdown_cell(f'`{root_package.name}`')} |",
+            f"| Package | {_markdown_code_cell(root_package.name)} |",
             f"| Version | {_markdown_cell(root_package.version)} |",
             f"| Ecosystem | {_markdown_cell(self.ecosystem or 'N/A')} |",
             f"| Date | {self.created_at().strftime('%Y-%m-%d')} |",
@@ -87,8 +94,10 @@ class MarkdownReportingWritter(ReportingWritter):
         if default_name is None:
             default_name = "sbom"
 
-        package_name, package_version = _split_package_spec(default_name)
-        root_row = _find_root_row(rows, package_name, package_version)
+        package_name, package_version = _split_package_spec(
+            default_name, self.ecosystem
+        )
+        root_row = _find_root_row(rows, package_name, package_version, self.ecosystem)
 
         if root_row is not None:
             return _RootPackage(
@@ -111,23 +120,50 @@ class MarkdownReportingWritter(ReportingWritter):
 def _markdown_cell(value: str | None) -> str:
     if value is None:
         return ""
-    return value.replace("|", "\\|")
+    return value.replace("|", "\\|").replace("_", "\\_")
+
+
+def _markdown_code_cell(value: str | None) -> str:
+    if value is None:
+        return ""
+    escaped_value = value.replace("|", "\\|")
+    return f"`{escaped_value}`"
 
 
 def _find_root_row(
-    rows: list[CombinedMetadata], package_name: str, package_version: str | None
+    rows: list[CombinedMetadata],
+    package_name: str,
+    package_version: str | None,
+    ecosystem: str | None = None,
 ) -> CombinedMetadata | None:
     for row in rows:
-        if row.component == package_name and (
+        if _package_name_matches(row.component, package_name, ecosystem) and (
             package_version is None or row.version == package_version
         ):
             return row
     return None
 
 
-def _split_package_spec(value: str) -> tuple[str, str | None]:
+def _package_name_matches(
+    row_component: str | None, package_name: str, ecosystem: str | None
+) -> bool:
+    if row_component is None:
+        return False
+    if ecosystem == "pypi":
+        return _normalize_pypi_name(row_component) == _normalize_pypi_name(package_name)
+    return row_component == package_name
+
+
+def _split_package_spec(
+    value: str, ecosystem: str | None = None
+) -> tuple[str, str | None]:
     if value.startswith("git@") or "://" in value:
         return value, None
+
+    if ecosystem == "pypi":
+        pypi_package_spec = _split_pypi_package_spec(value)
+        if pypi_package_spec is not None:
+            return pypi_package_spec
 
     if value.startswith("@"):
         version_separator = value.rfind("@", 1)
@@ -142,3 +178,20 @@ def _split_package_spec(value: str) -> tuple[str, str | None]:
     if not name or not version:
         return value, None
     return name, version
+
+
+def _split_pypi_package_spec(value: str) -> tuple[str, str | None] | None:
+    match = _PYPI_SPEC_PATTERN.match(value)
+    if match is None:
+        return None
+
+    name = match.group(1)
+    operator = match.group(2)
+    version = match.group(3)
+    if operator == "==" and version:
+        return name, version
+    return name, None
+
+
+def _normalize_pypi_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()

--- a/src/dd_license_attribution/report_generator/writters/markdown_reporting_writter.py
+++ b/src/dd_license_attribution/report_generator/writters/markdown_reporting_writter.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+
+from dd_license_attribution.adaptors.datetime import get_datetime_now
+from dd_license_attribution.metadata_collector.metadata import Metadata
+from dd_license_attribution.report_generator.writters.abstract_reporting_writter import (
+    ReportingWritter,
+)
+from dd_license_attribution.report_generator.writters.metadata_combiner import (
+    CombinedMetadata,
+    combine_metadata,
+)
+
+
+@dataclass
+class _RootPackage:
+    name: str
+    version: str | None
+    license: set[str]
+    copyright: set[str]
+    row: CombinedMetadata | None
+
+
+class MarkdownReportingWritter(ReportingWritter):
+    def __init__(
+        self,
+        document_name: str | None = None,
+        ecosystem: str | None = None,
+        created_at: Callable[[], datetime] = get_datetime_now,
+    ) -> None:
+        self.document_name = document_name
+        self.ecosystem = ecosystem
+        self.created_at = created_at
+
+    def write(self, metadata: list[Metadata]) -> str:
+        rows = combine_metadata(metadata)
+        root_package = self._get_root_package(metadata, rows)
+        dependency_rows = [
+            row
+            for row in rows
+            if root_package.row is None or row is not root_package.row
+        ]
+        lines = [
+            f"# License Compliance Report: {root_package.name}",
+            "",
+            "| Field | Value |",
+            "| --- | --- |",
+            f"| Package | {_markdown_cell(f'`{root_package.name}`')} |",
+            f"| Version | {_markdown_cell(root_package.version)} |",
+            f"| Ecosystem | {_markdown_cell(self.ecosystem or 'N/A')} |",
+            f"| Date | {self.created_at().strftime('%Y-%m-%d')} |",
+            f"| Dependencies | {len(dependency_rows)} |",
+            f"| License | {_markdown_cell(str(sorted(root_package.license)))} |",
+            f"| Copyright | {_markdown_cell(str(sorted(root_package.copyright)))} |",
+            "",
+            "## Third-Party Dependencies",
+            "",
+            "| Component | Origin | License | Copyright |",
+            "| --- | --- | --- | --- |",
+        ]
+
+        for row_data in dependency_rows:
+            lines.append(
+                "| "
+                f"{_markdown_cell(row_data.component)} | "
+                f"{_markdown_cell(row_data.origin)} | "
+                f"{_markdown_cell(str(sorted(row_data.license)))} | "
+                f"{_markdown_cell(str(sorted(row_data.copyright)))} |"
+            )
+
+        return "\n".join(lines) + "\n"
+
+    def _get_root_package(
+        self, metadata: list[Metadata], rows: list[CombinedMetadata]
+    ) -> _RootPackage:
+        default_name = self.document_name
+        if default_name is None and metadata and metadata[0].name:
+            default_name = metadata[0].name
+        if default_name is None:
+            default_name = "sbom"
+
+        package_name, package_version = _split_package_spec(default_name)
+        root_row = _find_root_row(rows, package_name, package_version)
+
+        if root_row is not None:
+            return _RootPackage(
+                name=root_row.component or package_name,
+                version=root_row.version or package_version,
+                license=root_row.license,
+                copyright=root_row.copyright,
+                row=root_row,
+            )
+
+        return _RootPackage(
+            name=package_name,
+            version=package_version,
+            license=set(),
+            copyright=set(),
+            row=None,
+        )
+
+
+def _markdown_cell(value: str | None) -> str:
+    if value is None:
+        return ""
+    return value.replace("|", "\\|")
+
+
+def _find_root_row(
+    rows: list[CombinedMetadata], package_name: str, package_version: str | None
+) -> CombinedMetadata | None:
+    for row in rows:
+        if row.component == package_name and (
+            package_version is None or row.version == package_version
+        ):
+            return row
+    return None
+
+
+def _split_package_spec(value: str) -> tuple[str, str | None]:
+    if value.startswith("git@") or "://" in value:
+        return value, None
+
+    if value.startswith("@"):
+        version_separator = value.rfind("@", 1)
+    else:
+        version_separator = value.rfind("@")
+
+    if version_separator <= 0:
+        return value, None
+
+    name = value[:version_separator]
+    version = value[version_separator + 1 :]
+    if not name or not version:
+        return value, None
+    return name, version

--- a/tests/unit/test_generate_sbom_command.py
+++ b/tests/unit/test_generate_sbom_command.py
@@ -10,8 +10,17 @@ from unittest.mock import ANY, Mock, call, patch
 from typer.testing import CliRunner
 
 from dd_license_attribution.cli.main_cli import app
+from dd_license_attribution.metadata_collector.metadata import Metadata
 
 runner = CliRunner()
+
+_SKIP_DEPENDENCY_STRATEGIES = [
+    "--no-pypi-strategy",
+    "--no-gopkg-strategy",
+    "--no-github-sbom-strategy",
+    "--no-npm-strategy",
+    "--no-scancode-strategy",
+]
 
 
 @patch("dd_license_attribution.cli.generate_sbom_command.ThreePhaseMetadataCollector")
@@ -463,6 +472,140 @@ def test_generate_sbom_supports_spdx_format(
     )
     mock_spdx_reporting_writter.return_value.write.assert_called_once_with([])
     mock_csv_reporting_writter.assert_not_called()
+
+
+@patch("dd_license_attribution.cli.generate_sbom_command.GitHub")
+@patch("dd_license_attribution.cli.generate_sbom_command.SourceCodeManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.PythonEnvManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.MetadataCollector")
+def test_generate_sbom_supports_markdown_format_stdout(
+    mock_metadata_collector: Mock,
+    mock_python_env_manager: Mock,
+    mock_source_code_manager: Mock,
+    mock_github: Mock,
+) -> None:
+    mock_metadata_collector.return_value.collect_metadata.return_value = [
+        Metadata(
+            name="repo",
+            version="1.0.0",
+            origin="https://github.com/org/repo",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["Copyright org"],
+        )
+    ]
+
+    result = runner.invoke(
+        app,
+        [
+            "generate-sbom",
+            "https://github.com/org/repo",
+            "--no-gh-auth",
+            "--format",
+            "markdown",
+            *_SKIP_DEPENDENCY_STRATEGIES,
+        ],
+        env={"GITHUB_TOKEN": ""},
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith("# License Compliance Report: github.com/org/repo")
+    assert "## Third-Party Dependencies" in result.stdout
+    mock_github.assert_called_once_with()
+    mock_source_code_manager.assert_called_once_with(
+        ANY, mock_github.return_value, 86400, None
+    )
+    mock_python_env_manager.assert_called_once_with(ANY, 86400)
+    mock_metadata_collector.assert_called_once_with(ANY)
+    mock_metadata_collector.return_value.collect_metadata.assert_called_once_with(
+        "https://github.com/org/repo"
+    )
+
+
+def test_generate_sbom_rejects_multiple_formats_without_output_dir() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "generate-sbom",
+            "https://github.com/org/repo",
+            "--no-gh-auth",
+            "--format",
+            "csv",
+            "--format",
+            "markdown",
+        ],
+        color=False,
+        env={"GITHUB_TOKEN": ""},
+    )
+
+    assert result.exit_code != 0
+    assert "Multiple --format values require --output-dir." in result.stderr
+
+
+@patch("dd_license_attribution.cli.generate_sbom_command.write_file")
+@patch("dd_license_attribution.cli.generate_sbom_command.create_dirs")
+@patch("dd_license_attribution.cli.generate_sbom_command.GitHub")
+@patch("dd_license_attribution.cli.generate_sbom_command.SourceCodeManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.PythonEnvManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.MetadataCollector")
+def test_generate_sbom_writes_multiple_output_formats_to_directory(
+    mock_metadata_collector: Mock,
+    mock_python_env_manager: Mock,
+    mock_source_code_manager: Mock,
+    mock_github: Mock,
+    mock_create_dirs: Mock,
+    mock_write_file: Mock,
+) -> None:
+    mock_metadata_collector.return_value.collect_metadata.return_value = [
+        Metadata(
+            name="repo",
+            version="1.0.0",
+            origin="https://github.com/org/repo",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["Copyright org"],
+        )
+    ]
+
+    result = runner.invoke(
+        app,
+        [
+            "generate-sbom",
+            "git@github.com:org/repo",
+            "--no-gh-auth",
+            "--format",
+            "csv",
+            "--format",
+            "markdown",
+            "--format",
+            "spdx",
+            "--output-dir",
+            "/tmp/ddla-out",
+            *_SKIP_DEPENDENCY_STRATEGIES,
+        ],
+        env={"GITHUB_TOKEN": ""},
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    mock_github.assert_called_once_with()
+    mock_source_code_manager.assert_called_once_with(
+        ANY, mock_github.return_value, 86400, None
+    )
+    mock_python_env_manager.assert_called_once_with(ANY, 86400)
+    mock_metadata_collector.assert_called_once_with(ANY)
+    mock_metadata_collector.return_value.collect_metadata.assert_called_once_with(
+        "git@github.com:org/repo"
+    )
+    mock_create_dirs.assert_called_once_with("/tmp/ddla-out")
+    mock_write_file.assert_has_calls(
+        [
+            call("/tmp/ddla-out/git@github.com_org_repo.csv", ANY),
+            call("/tmp/ddla-out/git@github.com_org_repo.md", ANY),
+            call("/tmp/ddla-out/git@github.com_org_repo.json", ANY),
+        ]
+    )
+    assert len(mock_write_file.call_args_list) == 3
 
 
 def test_generate_sbom_rejects_unknown_format() -> None:

--- a/tests/unit/test_generate_sbom_command.py
+++ b/tests/unit/test_generate_sbom_command.py
@@ -381,7 +381,7 @@ def test_generate_sbom_defaults_to_csv(
     result = runner.invoke(
         app,
         ["generate-sbom", "https://github.com/org/repo", "--no-gh-auth"],
-        env={"GITHUB_TOKEN": ""},
+        env={"GITHUB_TOKEN": "stale-token"},
     )
 
     assert result.exit_code == 0

--- a/tests/unit/test_generate_sbom_command.py
+++ b/tests/unit/test_generate_sbom_command.py
@@ -522,6 +522,62 @@ def test_generate_sbom_supports_markdown_format_stdout(
     )
 
 
+@patch("dd_license_attribution.cli.generate_sbom_command.GitHub")
+@patch("dd_license_attribution.cli.generate_sbom_command.SourceCodeManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.PypiPackageResolver")
+@patch("dd_license_attribution.cli.generate_sbom_command.PythonEnvManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.MarkdownReportingWritter")
+@patch("dd_license_attribution.cli.generate_sbom_command.MetadataCollector")
+def test_generate_sbom_canonicalizes_python_ecosystem_for_markdown_writer(
+    mock_metadata_collector: Mock,
+    mock_markdown_reporting_writter: Mock,
+    mock_python_env_manager: Mock,
+    mock_pypi_resolver: Mock,
+    mock_source_code_manager: Mock,
+    mock_github: Mock,
+) -> None:
+    mock_pypi_resolver.return_value.resolve_package.return_value = (
+        "/tmp/pypi_resolve/requests"
+    )
+    mock_metadata_collector.return_value.collect_metadata.return_value = []
+    mock_markdown_reporting_writter.return_value.write.return_value = "markdown-output"
+
+    result = runner.invoke(
+        app,
+        [
+            "generate-sbom",
+            "requests==2.31.0",
+            "--ecosystem",
+            "python",
+            "--no-gh-auth",
+            "--format",
+            "markdown",
+            "--no-scancode-strategy",
+        ],
+        env={"GITHUB_TOKEN": ""},
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == "markdown-output"
+    mock_github.assert_called_once_with()
+    mock_source_code_manager.assert_called_once_with(
+        ANY, mock_github.return_value, 86400, None
+    )
+    mock_pypi_resolver.assert_called_once_with(ANY)
+    mock_pypi_resolver.return_value.resolve_package.assert_called_once_with(
+        "requests==2.31.0"
+    )
+    mock_python_env_manager.assert_called_once_with(ANY, 86400)
+    mock_metadata_collector.assert_called_once_with(ANY)
+    mock_metadata_collector.return_value.collect_metadata.assert_called_once_with(
+        "requests==2.31.0"
+    )
+    mock_markdown_reporting_writter.assert_called_once_with(
+        document_name="requests==2.31.0", ecosystem="pypi"
+    )
+    mock_markdown_reporting_writter.return_value.write.assert_called_once_with([])
+
+
 def test_generate_sbom_rejects_multiple_formats_without_output_dir() -> None:
     result = runner.invoke(
         app,

--- a/tests/unit/test_generate_sbom_command.py
+++ b/tests/unit/test_generate_sbom_command.py
@@ -542,6 +542,54 @@ def test_generate_sbom_rejects_multiple_formats_without_output_dir() -> None:
     assert "Multiple --format values require --output-dir." in result.stderr
 
 
+@patch("dd_license_attribution.cli.generate_sbom_command.GitHub")
+@patch("dd_license_attribution.cli.generate_sbom_command.SourceCodeManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.PythonEnvManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.CSVReportingWritter")
+@patch("dd_license_attribution.cli.generate_sbom_command.MetadataCollector")
+def test_generate_sbom_deduplicates_repeated_stdout_format(
+    mock_metadata_collector: Mock,
+    mock_csv_reporting_writter: Mock,
+    mock_python_env_manager: Mock,
+    mock_source_code_manager: Mock,
+    mock_github: Mock,
+) -> None:
+    mock_metadata_collector.return_value.collect_metadata.return_value = []
+    mock_source_code_manager.return_value.get_canonical_urls.return_value = (
+        "https://github.com/org/repo",
+        None,
+    )
+    mock_csv_reporting_writter.return_value.write.return_value = "csv-output"
+
+    result = runner.invoke(
+        app,
+        [
+            "generate-sbom",
+            "https://github.com/org/repo",
+            "--no-gh-auth",
+            "--format",
+            "csv",
+            "--format",
+            "csv",
+        ],
+        env={"GITHUB_TOKEN": ""},
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == "csv-output"
+    mock_github.assert_called_once_with()
+    mock_source_code_manager.assert_called_once_with(
+        ANY, mock_github.return_value, 86400, None
+    )
+    mock_python_env_manager.assert_called_once_with(ANY, 86400)
+    mock_metadata_collector.assert_called_once_with(ANY)
+    mock_metadata_collector.return_value.collect_metadata.assert_called_once_with(
+        "https://github.com/org/repo"
+    )
+    mock_csv_reporting_writter.assert_called_once_with()
+    mock_csv_reporting_writter.return_value.write.assert_called_once_with([])
+
+
 @patch("dd_license_attribution.cli.generate_sbom_command.write_file")
 @patch("dd_license_attribution.cli.generate_sbom_command.create_dirs")
 @patch("dd_license_attribution.cli.generate_sbom_command.GitHub")
@@ -578,7 +626,11 @@ def test_generate_sbom_writes_multiple_output_formats_to_directory(
             "--format",
             "markdown",
             "--format",
+            "markdown",
+            "--format",
             "spdx",
+            "--format",
+            "csv",
             "--output-dir",
             "/tmp/ddla-out",
             *_SKIP_DEPENDENCY_STRATEGIES,

--- a/tests/unit/test_markdown_reporting_writter.py
+++ b/tests/unit/test_markdown_reporting_writter.py
@@ -86,6 +86,78 @@ def test_markdown_reporting_writter_writes_combined_metadata_table() -> None:
     assert markdown == expected
 
 
+def test_markdown_reporting_writter_escapes_underscores_in_dependency_cells() -> None:
+    metadata = [
+        Metadata(
+            name="root_project",
+            version="1.0.0",
+            origin="https://github.com/example/root_project",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["Copyright root"],
+        ),
+        Metadata(
+            name="dep_alpha",
+            version="1.0.0",
+            origin="https://github.com/example/dep_alpha",
+            local_src_path=None,
+            license=["MIT_License"],
+            copyright=["Copyright dep_alpha"],
+        ),
+    ]
+    markdown_report_writter = MarkdownReportingWritter(
+        document_name="root_project@1.0.0",
+        created_at=lambda: datetime(2026, 6, 24, 12, 30, 0),
+    )
+
+    markdown = markdown_report_writter.write(metadata)
+
+    assert "| Package | `root_project` |" in markdown
+    assert (
+        "| dep\\_alpha | https://github.com/example/dep\\_alpha | "
+        "['MIT\\_License'] | ['Copyright dep\\_alpha'] |"
+    ) in markdown
+
+
+def test_markdown_reporting_writter_matches_pypi_exact_version_spec_root() -> None:
+    metadata = [
+        Metadata(
+            name="requests",
+            version="2.31.0",
+            origin="https://github.com/psf/requests",
+            local_src_path=None,
+            license=["Apache-2.0"],
+            copyright=["Python Software Foundation"],
+        ),
+        Metadata(
+            name="urllib3",
+            version="2.2.0",
+            origin="https://github.com/urllib3/urllib3",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["urllib3 contributors"],
+        ),
+    ]
+    markdown_report_writter = MarkdownReportingWritter(
+        document_name="Requests==2.31.0",
+        ecosystem="pypi",
+        created_at=lambda: datetime(2026, 6, 24, 12, 30, 0),
+    )
+
+    markdown = markdown_report_writter.write(metadata)
+
+    assert markdown.startswith("# License Compliance Report: requests\n")
+    assert "| Package | `requests` |" in markdown
+    assert "| Version | 2.31.0 |" in markdown
+    assert "| Dependencies | 1 |" in markdown
+    assert "| License | ['Apache-2.0'] |" in markdown
+    assert "| requests | https://github.com/psf/requests |" not in markdown
+    assert (
+        "| urllib3 | https://github.com/urllib3/urllib3 | "
+        "['MIT'] | ['urllib3 contributors'] |"
+    ) in markdown
+
+
 def test_markdown_reporting_writter_uses_defaults_for_empty_metadata() -> None:
     markdown_report_writter = MarkdownReportingWritter(
         created_at=lambda: datetime(2026, 6, 24, 12, 30, 0),

--- a/tests/unit/test_markdown_reporting_writter.py
+++ b/tests/unit/test_markdown_reporting_writter.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+from datetime import datetime
+
+from dd_license_attribution.metadata_collector.metadata import Metadata
+from dd_license_attribution.report_generator.writters.markdown_reporting_writter import (
+    MarkdownReportingWritter,
+)
+
+
+def test_markdown_reporting_writter_writes_combined_metadata_table() -> None:
+    metadata = [
+        Metadata(
+            name="root-project",
+            version="1.0.0",
+            origin="https://github.com/example/root-project",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["Copyright root"],
+        ),
+        Metadata(
+            name="dep|alpha",
+            version="1.0.0",
+            origin="git+ssh://git@github.com/example/dep|alpha.git",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["Copyright | alpha"],
+        ),
+        Metadata(
+            name="dep|alpha",
+            version="1.0.0",
+            origin="git+ssh://git@github.com/example/dep|alpha.git",
+            local_src_path=None,
+            license=["Apache-2.0"],
+            copyright=["Copyright beta"],
+        ),
+        Metadata(
+            name="z-dep",
+            version="2.0.0",
+            origin="git://github.com/example/z-dep.git",
+            local_src_path=None,
+            license=["BSD-3-Clause"],
+            copyright=["Copyright z"],
+        ),
+    ]
+
+    markdown_report_writter = MarkdownReportingWritter(
+        document_name="root-project@1.0.0",
+        ecosystem="npm",
+        created_at=lambda: datetime(2026, 6, 24, 12, 30, 0),
+    )
+
+    markdown = markdown_report_writter.write(metadata)
+
+    expected = "\n".join(
+        [
+            "# License Compliance Report: root-project",
+            "",
+            "| Field | Value |",
+            "| --- | --- |",
+            "| Package | `root-project` |",
+            "| Version | 1.0.0 |",
+            "| Ecosystem | npm |",
+            "| Date | 2026-06-24 |",
+            "| Dependencies | 2 |",
+            "| License | ['MIT'] |",
+            "| Copyright | ['Copyright root'] |",
+            "",
+            "## Third-Party Dependencies",
+            "",
+            "| Component | Origin | License | Copyright |",
+            "| --- | --- | --- | --- |",
+            "| dep\\|alpha | git+ssh://git@github.com/example/dep\\|alpha.git | "
+            "['Apache-2.0', 'MIT'] | "
+            "['Copyright beta', 'Copyright \\| alpha'] |",
+            "| z-dep | git://github.com/example/z-dep.git | "
+            "['BSD-3-Clause'] | ['Copyright z'] |",
+            "",
+        ]
+    )
+    assert markdown == expected
+
+
+def test_markdown_reporting_writter_uses_defaults_for_empty_metadata() -> None:
+    markdown_report_writter = MarkdownReportingWritter(
+        created_at=lambda: datetime(2026, 6, 24, 12, 30, 0),
+    )
+
+    markdown = markdown_report_writter.write([])
+
+    expected = "\n".join(
+        [
+            "# License Compliance Report: sbom",
+            "",
+            "| Field | Value |",
+            "| --- | --- |",
+            "| Package | `sbom` |",
+            "| Version |  |",
+            "| Ecosystem | N/A |",
+            "| Date | 2026-06-24 |",
+            "| Dependencies | 0 |",
+            "| License | [] |",
+            "| Copyright | [] |",
+            "",
+            "## Third-Party Dependencies",
+            "",
+            "| Component | Origin | License | Copyright |",
+            "| --- | --- | --- | --- |",
+            "",
+        ]
+    )
+    assert markdown == expected
+
+
+def test_markdown_reporting_writter_uses_first_metadata_name_and_empty_none_cells() -> (
+    None
+):
+    metadata = [
+        Metadata(
+            name="root-project",
+            version="1.0.0",
+            origin="https://github.com/example/root-project",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=["Copyright root"],
+        ),
+        Metadata(
+            name=None,
+            version=None,
+            origin=None,
+            local_src_path=None,
+            license=[],
+            copyright=[],
+        ),
+    ]
+    markdown_report_writter = MarkdownReportingWritter(
+        created_at=lambda: datetime(2026, 6, 24, 12, 30, 0),
+    )
+
+    markdown = markdown_report_writter.write(metadata)
+
+    assert markdown.startswith("# License Compliance Report: root-project\n")
+    assert "| Dependencies | 1 |" in markdown
+    assert "| License | ['MIT'] |" in markdown
+    assert "| Copyright | ['Copyright root'] |" in markdown
+    assert "|  |  | [] | [] |" in markdown
+
+
+def test_markdown_reporting_writter_handles_scoped_packages_and_preserves_origins() -> (
+    None
+):
+    metadata = [
+        Metadata(
+            name="@scope/root",
+            version="1.2.3",
+            origin="github.com/scope/root",
+            local_src_path=None,
+            license=["Apache-2.0"],
+            copyright=["Scope"],
+        ),
+        Metadata(
+            name="dep-a",
+            version="1.0.0",
+            origin="git@github.com:example/dep-a.git",
+            local_src_path=None,
+            license=["MIT"],
+            copyright=[],
+        ),
+        Metadata(
+            name="dep-b",
+            version="2.0.0",
+            origin="git+https://github.com/example/dep-b.git",
+            local_src_path=None,
+            license=["BSD-3-Clause"],
+            copyright=[],
+        ),
+        Metadata(
+            name="dep-c",
+            version="3.0.0",
+            origin="github.com/example/dep-c",
+            local_src_path=None,
+            license=["ISC"],
+            copyright=[],
+        ),
+    ]
+    markdown_report_writter = MarkdownReportingWritter(
+        document_name="@scope/root@1.2.3",
+        created_at=lambda: datetime(2026, 6, 24, 12, 30, 0),
+    )
+
+    markdown = markdown_report_writter.write(metadata)
+
+    assert markdown.startswith("# License Compliance Report: @scope/root\n")
+    assert "| Version | 1.2.3 |" in markdown
+    assert "| dep-a | git@github.com:example/dep-a.git | ['MIT'] | [] |" in markdown
+    assert (
+        "| dep-b | git+https://github.com/example/dep-b.git | ['BSD-3-Clause'] | [] |"
+    ) in markdown
+    assert "| dep-c | github.com/example/dep-c | ['ISC'] | [] |" in markdown
+
+
+def test_markdown_reporting_writter_preserves_unsplit_document_names() -> None:
+    git_markdown_report_writter = MarkdownReportingWritter(
+        document_name="git@github.com:example/root",
+        created_at=lambda: datetime(2026, 6, 24, 12, 30, 0),
+    )
+    malformed_markdown_report_writter = MarkdownReportingWritter(
+        document_name="root@",
+        created_at=lambda: datetime(2026, 6, 24, 12, 30, 0),
+    )
+
+    git_markdown = git_markdown_report_writter.write([])
+    malformed_markdown = malformed_markdown_report_writter.write([])
+
+    assert git_markdown.startswith(
+        "# License Compliance Report: git@github.com:example/root\n"
+    )
+    assert "| Package | `git@github.com:example/root` |" in git_markdown
+    assert "| Version |  |" in git_markdown
+    assert malformed_markdown.startswith("# License Compliance Report: root@\n")
+    assert "| Package | `root@` |" in malformed_markdown
+    assert "| Version |  |" in malformed_markdown


### PR DESCRIPTION
## Summary

Adds Markdown as a first-class `generate-sbom --format` output and lets callers request multiple report formats in a single `generate-sbom` run with `--output-dir`.

This keeps metadata collection single-pass: the command collects metadata once, runs license checks once, then renders each requested report writer over the same metadata. That makes CSV, Markdown, and SPDX outputs comparable and avoids duplicate resolver/collector work.

## What changed

- Added `MarkdownReportingWritter`.
  - Renders a license compliance report with a root package summary and a third-party dependency table.
  - Shows root package version, ecosystem, date, dependency count, root license, and root copyright.
  - Excludes the root package from the dependency table.
  - Preserves dependency origins exactly as collected in metadata; it does not normalize or resolve URLs.
  - Escapes Markdown table pipe characters in cells.
- Extended `generate-sbom --format` to be repeatable.
  - Supported values are now `csv`, `spdx`, and `markdown`.
  - Multiple formats require `--output-dir` and write one file per format.
  - Single-format behavior remains stdout-oriented for piping/redirection.
- Added `--output-dir` for multi-output generation.
  - The command creates the directory if needed.
  - Output extensions are `.csv`, `.md`, and `.json`.
- Kept `generate-sbom-csv` compatibility by forcing CSV output through the new internal `output_formats` path.
- Fixed `--no-gh-auth` precedence so it ignores `GITHUB_TOKEN` from the environment when the user explicitly asks for unauthenticated GitHub access.
- Updated `CHANGELOG.md` for the user-visible Markdown and multi-output changes.

## Why

The Markdown exporter needs to match the previous report shape closely enough for review while being produced directly by dd-license-attribution. The CLI also needs a way to emit CSV, Markdown, and SPDX together from the same metadata collection so users can compare the outputs without re-running package resolution and collection.

The `--no-gh-auth` fix addresses a local validation trap: Typer can populate `github_token` from `GITHUB_TOKEN` even when `--no-gh-auth` is present. With a stale or invalid token, runs that were meant to be unauthenticated could still use that token and get different GitHub API behavior.

## Verification

Static and unit checks:

- `pipenv run isort --check-only src/ tests/`
- `pipenv run black --check src/ tests/`
- `pipenv run ruff check src/ tests/`
- `PYTHONPATH=src pipenv run mypy src/ tests/`
- `PYTHONPATH=src pipenv run pytest tests/unit --cov=src/dd_license_attribution --cov-fail-under=95`
  - Result: `459 passed`, total coverage `95.18%`.

End-to-end CLI validation against a real npm package:

```bash
env GITHUB_TOKEN= PYTHONPATH=src pipenv run dd-license-attribution generate-sbom \
  datadog-lambda-js@12.140.0 \
  --ecosystem npm \
  --no-gh-auth \
  --format csv \
  --format markdown \
  --format spdx \
  --output-dir /tmp/ddla-out-datadog-lambda-js-pr
```

Observed results:

- Command exited successfully.
- Wrote all three expected files:
  - `/tmp/ddla-out-datadog-lambda-js-pr/datadog-lambda-js@12.140.0.csv`
  - `/tmp/ddla-out-datadog-lambda-js-pr/datadog-lambda-js@12.140.0.md`
  - `/tmp/ddla-out-datadog-lambda-js-pr/datadog-lambda-js@12.140.0.json`
- SPDX JSON parsed successfully with `python -m json.tool`.
- Markdown output identified `datadog-lambda-js` as the report package, showed version `12.140.0`, ecosystem `npm`, 15 dependencies, root license `['Apache-2.0']`, and root copyright `['Datadog']`.
- Representative dependency rows were present, including Smithy rows with the metadata-provided `https://github.com/smithy-lang/smithy-typescript` origins.
- Expected warning reviewed: `type-fest` has license `((MIT OR CC0-1.0))`, which triggers the existing non-OSI/SPDX warning path.

Comparison with the previous Markdown output at `/tmp/ddla-out-npm/npm_datadog-lambda-js_12.140.0_datadog-lambda-js-report-install.md` showed only the expected report-shape changes near the headers: Markdown separator style, current date, and the added `Version`, `License`, and `Copyright` summary rows. Dependency rows matched for the inspected diff segment.