### PR TITLE
feat(ci): enable Datadog code coverage in Test Optimization steps

### DIFF
--- a/.github/workflows/coverage-regression.yml
+++ b/.github/workflows/coverage-regression.yml
@@ -49,6 +49,7 @@ jobs:
           languages: python
           api_key: ${{ steps.dd-sts.outputs.api_key }}
           site: datadoghq.com
+          code_coverage: "true"
 
       - name: Run coverage on target branch
         env:

--- a/.github/workflows/coverage-unit-test.yml
+++ b/.github/workflows/coverage-unit-test.yml
@@ -54,6 +54,7 @@ jobs:
           languages: python
           api_key: ${{ steps.dd-sts.outputs.api_key }}
           site: datadoghq.com
+          code_coverage: "true"
 
       - name: Run contract tests
         env:


### PR DESCRIPTION
## Summary

- Add `code_coverage: "true"` to the `Configure Datadog Test Optimization` step in `coverage-unit-test.yml`
- Add `code_coverage: "true"` to the `Configure Datadog Test Optimization` step in `coverage-regression.yml`

Without this flag, the Datadog tracer instruments test runs but does not enable coverage collection or report it to the platform, which is why the repository was not appearing in the **Software Delivery > Code Coverage** UI.

## Test plan

- [ ] Merge and confirm CI passes
- [ ] Verify the repository appears under Software Delivery > Code Coverage in Datadog after the next CI run