### PR TITLE
test(ci): exercise reusable action from PR #225 as an external caller

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -216,8 +216,13 @@ jobs:
       # would (`uses: owner/repo@sha`, not a local `uses: ./`), pinned to the
       # commit under review in PR #225 (DataDog/dd-license-attribution#225).
       # Once that PR merges, this can be repinned to a released tag or `main`.
+      #
+      # Unlike PR #225's own dogfood step, this always authenticates: it runs
+      # the already-reviewed action against this repository's own content,
+      # not untrusted PR-authored code, so there is no reason to withhold the
+      # token — and doing so throttles GitHub API calls heavily.
       - name: Validate LICENSE-3rdparty.csv using the reusable action
         uses: DataDog/dd-license-attribution@e264b48df60bc5618728bfabbb2dc01dc322fe99 # romain.marcadier/reusable-github-action
         with:
           override-spec: .ddla-overrides
-          github-token: ${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -201,3 +201,23 @@ jobs:
       - name: Test generate-overrides command with clean CSV
         run: |
           dd-license-attribution generate-overrides LICENSE-3rdparty.csv -o test-overrides.json
+
+  test-reusable-action:
+    runs-on: ubuntu-latest
+    name: reusable action (pinned to PR #225 commit)
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Exercises the reusable action end-to-end the way an external caller
+      # would (`uses: owner/repo@sha`, not a local `uses: ./`), pinned to the
+      # commit under review in PR #225 (DataDog/dd-license-attribution#225).
+      # Once that PR merges, this can be repinned to a released tag or `main`.
+      - name: Validate LICENSE-3rdparty.csv using the reusable action
+        uses: DataDog/dd-license-attribution@e264b48df60bc5618728bfabbb2dc01dc322fe99 # romain.marcadier/reusable-github-action
+        with:
+          override-spec: .ddla-overrides
+          github-token: ${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}


### PR DESCRIPTION
## Summary
- Adds a `test-reusable-action` job to `integration-test.yml` that invokes the new composite action added in #225, but referenced the way an external caller would (`uses: DataDog/dd-license-attribution@<sha>`), pinned to that PR's current head commit (`e264b48`).
- Purpose: validate the action works end-to-end (mirror building, cloning the branch under test, SBOM generation/comparison) before merging #225, without touching that PR's branch.
- This is a temporary validation PR. Once #225 merges (or is confirmed working here), this PR can be closed/superseded — the pin should not ship to main as-is.

## Test plan
- [ ] CI passes on this PR (the new `test-reusable-action` job succeeds)
- [ ] If green, approve #225