### PR TITLE
fix(npm): reject incomplete registry metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `generate-sbom-csv` is deprecated in favor of `generate-sbom --format csv`; it still works and emits a deprecation warning.
 
 ### Fixed
+- Fixed transient npm registry failures replacing package attribution with empty metadata. Registry requests are now retried and SBOM generation fails if metadata remains unavailable.
 - Fixed repeated action invocations overwriting earlier SBOM outputs by creating a unique output file for each invocation.
 - Fixed the action's default tokenless mode failing before a scan because it did not pass `--no-gh-auth` when `github-token` was empty.
 - Fixed the action requiring `csv-path` to exist during structural-only validation with `compare: false`.

--- a/src/dd_license_attribution/cli/generate_sbom_command.py
+++ b/src/dd_license_attribution/cli/generate_sbom_command.py
@@ -73,6 +73,7 @@ from dd_license_attribution.metadata_collector.strategies.gopkg_collection_strat
 )
 from dd_license_attribution.metadata_collector.strategies.npm_collection_strategy import (
     NpmMetadataCollectionStrategy,
+    NpmRegistryMetadataError,
 )
 from dd_license_attribution.metadata_collector.strategies.override_strategy import (
     OverrideCollectionStrategy,
@@ -821,7 +822,11 @@ def generate_sbom(
             metadata_collector = MetadataCollector(strategies)
         try:
             metadata = metadata_collector.collect_metadata(package)
-        except (NonAccessibleRepository, UnauthorizedRepository) as e:
+        except (
+            NonAccessibleRepository,
+            NpmRegistryMetadataError,
+            UnauthorizedRepository,
+        ) as e:
             logger.error(str(e))
             sys.exit(1)
         except PyEnvRuntimeError as e:

--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -10,6 +10,8 @@
 import json
 import logging
 import re
+from random import uniform
+from time import sleep
 from typing import Any
 
 import requests
@@ -39,6 +41,14 @@ from dd_license_attribution.metadata_collector.strategies.abstract_collection_st
 
 # Get application-specific logger
 logger = logging.getLogger("dd_license_attribution")
+
+_NPM_REGISTRY_MAX_ATTEMPTS = 3
+_NPM_REGISTRY_RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+_NPM_REGISTRY_TIMEOUT_SECONDS = 5
+
+
+class NpmRegistryMetadataError(RuntimeError):
+    """Raised when npm registry metadata cannot be fetched."""
 
 
 def _semver_sort_key(version: str) -> semver.Version:
@@ -413,32 +423,54 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
     def _fetch_npm_registry_metadata(
         self, dep_name: str, version: str
     ) -> tuple[list[str], list[str], dict[str, Any] | None]:
-        license = []
-        copyright = []
-        pkg_data = None
+        url = f"https://registry.npmjs.org/{dep_name}/{version}"
+        attempt = 1
 
-        try:
-            resp = requests.get(
-                f"https://registry.npmjs.org/{dep_name}/{version}",
-                timeout=5,
-            )
-            if resp.status_code == 200:
-                pkg_data = resp.json()
-                license = self._extract_license_from_pkg_data(pkg_data)
-                copyright = self._extract_copyright_from_pkg_data(pkg_data)
+        while True:
+            try:
+                response = requests.get(url, timeout=_NPM_REGISTRY_TIMEOUT_SECONDS)
+            except (requests.ConnectionError, requests.Timeout) as error:
+                failure = str(error)
+            except requests.RequestException as error:
+                raise NpmRegistryMetadataError(
+                    f"Failed to fetch npm registry metadata for "
+                    f"{dep_name}@{version}: {error}"
+                ) from error
             else:
-                logger.warning(
-                    "Failed to fetch npm registry metadata for "
-                    f"{dep_name}@{version}: {resp.status_code}, "
-                    f"{resp.text}"
-                )
-        except requests.RequestException as e:
-            logger.warning(
-                "Failed to fetch npm registry metadata for "
-                f"{dep_name}@{version}: {e}"
-            )
+                if response.status_code == 200:
+                    package_data = response.json()
+                    return (
+                        self._extract_license_from_pkg_data(package_data),
+                        self._extract_copyright_from_pkg_data(package_data),
+                        package_data,
+                    )
 
-        return license, copyright, pkg_data
+                failure = f"{response.status_code}, {response.text}"
+                if response.status_code not in _NPM_REGISTRY_RETRYABLE_STATUS_CODES:
+                    raise NpmRegistryMetadataError(
+                        f"Failed to fetch npm registry metadata for "
+                        f"{dep_name}@{version}: {failure}"
+                    )
+
+            if attempt == _NPM_REGISTRY_MAX_ATTEMPTS:
+                raise NpmRegistryMetadataError(
+                    f"Failed to fetch npm registry metadata for "
+                    f"{dep_name}@{version} after {attempt} attempts: {failure}"
+                )
+
+            delay = 2 ** (attempt - 1) + uniform(0, 1)
+            logger.warning(
+                "Failed to fetch npm registry metadata for %s@%s "
+                "(attempt %d/%d): %s; retrying in %.2f seconds",
+                dep_name,
+                version,
+                attempt,
+                _NPM_REGISTRY_MAX_ATTEMPTS,
+                failure,
+                delay,
+            )
+            sleep(delay)
+            attempt += 1
 
     def _determine_origin(
         self,
@@ -522,6 +554,7 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
         self, metadata: list[Metadata], dependencies: dict[str, str]
     ) -> list[Metadata]:
         updated_metadata = metadata.copy()
+        registry_failures: list[str] = []
 
         # Apply project scope filters - filter transitive-only if needed
         if self.only_transitive:
@@ -539,9 +572,13 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
             if idx % 50 == 0 or idx == total_deps:
                 logger.info("Progress: %d/%d dependencies processed", idx, total_deps)
 
-            license, copyright, pkg_data = self._fetch_npm_registry_metadata(
-                dep_name, version
-            )
+            try:
+                license, copyright, pkg_data = self._fetch_npm_registry_metadata(
+                    dep_name, version
+                )
+            except NpmRegistryMetadataError as error:
+                registry_failures.append(str(error))
+                continue
 
             origin = self._determine_origin(pkg_data, dep_name)
 
@@ -571,6 +608,12 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
                         copyright=copyright,
                     )
                 )
+
+        if registry_failures:
+            raise NpmRegistryMetadataError(
+                "Npm registry metadata is incomplete:\n- "
+                + "\n- ".join(registry_failures)
+            )
 
         return updated_metadata
 

--- a/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/npm_collection_strategy.py
@@ -43,8 +43,9 @@ from dd_license_attribution.metadata_collector.strategies.abstract_collection_st
 logger = logging.getLogger("dd_license_attribution")
 
 _NPM_REGISTRY_MAX_ATTEMPTS = 3
-_NPM_REGISTRY_RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+_NPM_REGISTRY_RETRYABLE_STATUS_CODES = {408, 429}
 _NPM_REGISTRY_TIMEOUT_SECONDS = 5
+_NPM_REGISTRY_MAX_RETRY_DELAY_SECONDS = _NPM_REGISTRY_TIMEOUT_SECONDS
 
 
 class NpmRegistryMetadataError(RuntimeError):
@@ -427,9 +428,14 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
         attempt = 1
 
         while True:
+            retry_after: str | None = None
             try:
                 response = requests.get(url, timeout=_NPM_REGISTRY_TIMEOUT_SECONDS)
-            except (requests.ConnectionError, requests.Timeout) as error:
+            except (
+                requests.ConnectionError,
+                requests.Timeout,
+                requests.exceptions.ChunkedEncodingError,
+            ) as error:
                 failure = str(error)
             except requests.RequestException as error:
                 raise NpmRegistryMetadataError(
@@ -446,11 +452,16 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
                     )
 
                 failure = f"{response.status_code}, {response.text}"
-                if response.status_code not in _NPM_REGISTRY_RETRYABLE_STATUS_CODES:
+                if (
+                    response.status_code not in _NPM_REGISTRY_RETRYABLE_STATUS_CODES
+                    and not 500 <= response.status_code < 600
+                ):
                     raise NpmRegistryMetadataError(
                         f"Failed to fetch npm registry metadata for "
                         f"{dep_name}@{version}: {failure}"
                     )
+
+                retry_after = response.headers.get("Retry-After")
 
             if attempt == _NPM_REGISTRY_MAX_ATTEMPTS:
                 raise NpmRegistryMetadataError(
@@ -458,7 +469,17 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
                     f"{dep_name}@{version} after {attempt} attempts: {failure}"
                 )
 
-            delay = 2 ** (attempt - 1) + uniform(0, 1)
+            if isinstance(retry_after, str) and retry_after.strip().isdecimal():
+                delay = int(retry_after)
+                if delay > _NPM_REGISTRY_MAX_RETRY_DELAY_SECONDS:
+                    raise NpmRegistryMetadataError(
+                        f"Failed to fetch npm registry metadata for "
+                        f"{dep_name}@{version}: Retry-After value {delay} exceeds "
+                        f"the maximum retry delay of "
+                        f"{_NPM_REGISTRY_MAX_RETRY_DELAY_SECONDS} seconds"
+                    )
+            else:
+                delay = 2 ** (attempt - 1) + uniform(0, 1)
             logger.warning(
                 "Failed to fetch npm registry metadata for %s@%s "
                 "(attempt %d/%d): %s; retrying in %.2f seconds",
@@ -554,7 +575,6 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
         self, metadata: list[Metadata], dependencies: dict[str, str]
     ) -> list[Metadata]:
         updated_metadata = metadata.copy()
-        registry_failures: list[str] = []
 
         # Apply project scope filters - filter transitive-only if needed
         if self.only_transitive:
@@ -572,13 +592,9 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
             if idx % 50 == 0 or idx == total_deps:
                 logger.info("Progress: %d/%d dependencies processed", idx, total_deps)
 
-            try:
-                license, copyright, pkg_data = self._fetch_npm_registry_metadata(
-                    dep_name, version
-                )
-            except NpmRegistryMetadataError as error:
-                registry_failures.append(str(error))
-                continue
+            license, copyright, pkg_data = self._fetch_npm_registry_metadata(
+                dep_name, version
+            )
 
             origin = self._determine_origin(pkg_data, dep_name)
 
@@ -608,12 +624,6 @@ class NpmMetadataCollectionStrategy(MetadataCollectionStrategy):
                         copyright=copyright,
                     )
                 )
-
-        if registry_failures:
-            raise NpmRegistryMetadataError(
-                "Npm registry metadata is incomplete:\n- "
-                + "\n- ".join(registry_failures)
-            )
 
         return updated_metadata
 

--- a/tests/unit/test_generate_sbom_command.py
+++ b/tests/unit/test_generate_sbom_command.py
@@ -11,6 +11,9 @@ from typer.testing import CliRunner
 
 from dd_license_attribution.cli.main_cli import app
 from dd_license_attribution.metadata_collector.metadata import Metadata
+from dd_license_attribution.metadata_collector.strategies.npm_collection_strategy import (
+    NpmRegistryMetadataError,
+)
 
 runner = CliRunner()
 
@@ -130,6 +133,40 @@ def test_without_experimental_strategy_uses_metadata_collector(
     assert result.exit_code == 0, result.output
     mock_metadata_collector.assert_called_once()
     mock_three_phase_collector.assert_not_called()
+
+
+@patch("dd_license_attribution.cli.generate_sbom_command.MetadataCollector")
+@patch("dd_license_attribution.cli.generate_sbom_command.GitHub")
+@patch("dd_license_attribution.cli.generate_sbom_command.SourceCodeManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.PythonEnvManager")
+@patch("dd_license_attribution.cli.generate_sbom_command.CSVReportingWritter")
+def test_npm_registry_metadata_error_exits_cleanly(
+    mock_csv: Mock,
+    mock_python_env_manager: Mock,
+    mock_source_code_manager: Mock,
+    mock_github: Mock,
+    mock_metadata_collector: Mock,
+) -> None:
+    mock_metadata_collector.return_value.collect_metadata.side_effect = (
+        NpmRegistryMetadataError("Failed to fetch npm registry metadata")
+    )
+    mock_source_code_manager.return_value.get_canonical_urls.return_value = (
+        "https://github.com/org/repo",
+        None,
+    )
+    mock_csv.return_value.write.return_value = ""
+
+    result = runner.invoke(
+        app,
+        ["generate-sbom", "https://github.com/org/repo", "--no-gh-auth"],
+        env={"GITHUB_TOKEN": ""},
+    )
+
+    assert result.exit_code == 1
+    assert "Failed to fetch npm registry metadata" in result.output
+    mock_metadata_collector.return_value.collect_metadata.assert_called_once_with(
+        "https://github.com/org/repo"
+    )
 
 
 @patch("dd_license_attribution.cli.generate_sbom_command.ThreePhaseMetadataCollector")

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -10,7 +10,9 @@ import logging
 from typing import Any
 from unittest import mock
 
+import pytest
 import pytest_mock
+import requests
 from pytest import LogCaptureFixture
 
 from dd_license_attribution.artifact_management.artifact_manager import (
@@ -601,7 +603,7 @@ def test_npm_collection_strategy_handles_missing_root_package(
     assert mock_requests.call_count == 1
 
 
-def test_npm_collection_strategy_handles_registry_api_failures(
+def test_npm_collection_strategy_retries_registry_api_failures(
     mocker: pytest_mock.MockFixture,
 ) -> None:
     source_code_manager_mock = create_source_code_manager_mock()
@@ -615,7 +617,11 @@ def test_npm_collection_strategy_handles_registry_api_failures(
     }
 
     requests_responses = [
-        mock.Mock(status_code=404),  # dep1 not found
+        mock.Mock(
+            status_code=503,
+            text="Service Unavailable",
+        ),
+        mock.Mock(status_code=200, json=lambda: {"license": "MIT", "author": "Alice"}),
         mock.Mock(
             status_code=200, json=lambda: {"license": "Apache-2.0", "author": "Bob"}
         ),
@@ -629,6 +635,15 @@ def test_npm_collection_strategy_handles_registry_api_failures(
         mock_run_command,
         mock_requests,
     ) = setup_npm_strategy_mocks(mocker, package_lock, package_json, requests_responses)
+    mock_sleep = mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.sleep"
+    )
+    mock_uniform = mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.uniform",
+        return_value=0.25,
+    )
 
     strategy = NpmMetadataCollectionStrategy(
         "package1", source_code_manager_mock, ProjectScope.ALL
@@ -652,8 +667,8 @@ def test_npm_collection_strategy_handles_registry_api_failures(
 
     assert dep1_meta is not None
     assert dep2_meta is not None
-    assert dep1_meta.license == []  # Should be empty due to 404
-    assert dep2_meta.license == ["Apache-2.0"]  # Should have license
+    assert dep1_meta.license == ["MIT"]
+    assert dep2_meta.license == ["Apache-2.0"]
     # Verify npm install (via run_command_with_check) and npm list were called
     assert mock_run_command.call_count == 2
     mock_run_command.assert_any_call(
@@ -668,22 +683,43 @@ def test_npm_collection_strategy_handles_registry_api_failures(
     assert mock_exists.call_count == 2  # package.json, yarn.lock
     assert mock_path_join.call_count == 2  # package.json, yarn.lock
     assert mock_open.call_count == 1  # package.json
-    assert mock_requests.call_count == 2
+    assert mock_requests.call_count == 3
+    mock_requests.assert_has_calls(
+        [
+            mock.call("https://registry.npmjs.org/dep1/1.0.0", timeout=5),
+            mock.call("https://registry.npmjs.org/dep1/1.0.0", timeout=5),
+            mock.call("https://registry.npmjs.org/dep2/2.0.0", timeout=5),
+        ]
+    )
+    mock_sleep.assert_called_once_with(1.25)
+    mock_uniform.assert_called_once_with(0, 1)
 
 
-def test_npm_collection_strategy_logs_warning_on_non_200_response(
+@pytest.mark.parametrize(
+    ("registry_failure", "expected_failure"),
+    [
+        (mock.Mock(status_code=404, text="Not Found"), "404, Not Found"),
+        (
+            requests.exceptions.InvalidURL("invalid registry URL"),
+            "invalid registry URL",
+        ),
+    ],
+)
+def test_npm_collection_strategy_aggregates_non_retryable_registry_failures(
     mocker: pytest_mock.MockFixture,
-    caplog: LogCaptureFixture,
+    registry_failure: mock.Mock | requests.RequestException,
+    expected_failure: str,
 ) -> None:
     source_code_manager_mock = create_source_code_manager_mock()
     package_json: dict[str, Any] = {}
     package_lock = {
         "packages": {
-            "": {"dependencies": {"dep1": "1.0.0"}},
+            "": {"dependencies": {"dep1": "1.0.0", "dep2": "2.0.0"}},
             "node_modules/dep1": {"version": "1.0.0", "dependencies": {}},
+            "node_modules/dep2": {"version": "2.0.0", "dependencies": {}},
         }
     }
-    requests_responses = [mock.Mock(status_code=404, text="Not Found")]
+    requests_responses: list[mock.Mock] = []
 
     (
         mock_exists,
@@ -693,6 +729,10 @@ def test_npm_collection_strategy_logs_warning_on_non_200_response(
         mock_run_command,
         mock_requests,
     ) = setup_npm_strategy_mocks(mocker, package_lock, package_json, requests_responses)
+    mock_requests.side_effect = [
+        registry_failure,
+        mock.Mock(status_code=404, text="Not Found"),
+    ]
 
     strategy = NpmMetadataCollectionStrategy(
         "package1", source_code_manager_mock, ProjectScope.ALL
@@ -708,20 +748,17 @@ def test_npm_collection_strategy_logs_warning_on_non_200_response(
         ),
     ]
 
-    with caplog.at_level(logging.WARNING):
-        result = strategy.augment_metadata(initial_metadata)
+    with pytest.raises(RuntimeError) as raised:
+        strategy.augment_metadata(initial_metadata)
 
-    expected_warning = (
-        "Failed to fetch npm registry metadata for dep1@1.0.0: 404, Not Found"
+    assert (
+        "Failed to fetch npm registry metadata for dep1@1.0.0: "
+        f"{expected_failure}" in str(raised.value)
     )
-    assert any(expected_warning in record.message for record in caplog.records)
-
-    assert len(result) == 2
-    dep_meta = next((m for m in result if m.name == "dep1"), None)
-    assert dep_meta is not None
-    assert dep_meta.version == "1.0.0"
-    assert dep_meta.license == []
-    assert dep_meta.copyright == []
+    assert (
+        "Failed to fetch npm registry metadata for dep2@2.0.0: 404, Not Found"
+        in str(raised.value)
+    )
     # Verify npm install (via run_command_with_check) and npm list were called
     assert mock_run_command.call_count == 2
     mock_run_command.assert_any_call(
@@ -736,7 +773,128 @@ def test_npm_collection_strategy_logs_warning_on_non_200_response(
     assert mock_exists.call_count == 2  # package.json, yarn.lock
     assert mock_path_join.call_count == 2  # package.json, yarn.lock
     assert mock_open.call_count == 1  # package.json
-    assert mock_requests.call_count == 1
+    assert mock_requests.call_count == 2
+    mock_requests.assert_has_calls(
+        [
+            mock.call("https://registry.npmjs.org/dep1/1.0.0", timeout=5),
+            mock.call("https://registry.npmjs.org/dep2/2.0.0", timeout=5),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    ("registry_failures", "expected_failure"),
+    [
+        (
+            [
+                requests.ReadTimeout("registry timeout"),
+                requests.ReadTimeout("registry timeout"),
+                requests.ReadTimeout("registry timeout"),
+            ],
+            "registry timeout",
+        ),
+        (
+            [
+                mock.Mock(
+                    status_code=503,
+                    text="Service Unavailable",
+                    headers={},
+                ),
+                mock.Mock(
+                    status_code=503,
+                    text="Service Unavailable",
+                    headers={},
+                ),
+                mock.Mock(
+                    status_code=503,
+                    text="Service Unavailable",
+                    headers={},
+                ),
+            ],
+            "503, Service Unavailable",
+        ),
+    ],
+)
+def test_npm_collection_strategy_fails_after_transient_registry_failures(
+    mocker: pytest_mock.MockFixture,
+    registry_failures: list[mock.Mock | requests.RequestException],
+    expected_failure: str,
+) -> None:
+    source_code_manager_mock = create_source_code_manager_mock()
+    package_json: dict[str, Any] = {}
+    package_lock = {
+        "packages": {
+            "": {"dependencies": {"dep1": "1.0.0"}},
+            "node_modules/dep1": {"version": "1.0.0", "dependencies": {}},
+        }
+    }
+    requests_responses: list[mock.Mock] = []
+
+    (
+        mock_exists,
+        mock_path_join,
+        mock_open,
+        mock_output_from_command,
+        mock_run_command,
+        mock_requests,
+    ) = setup_npm_strategy_mocks(mocker, package_lock, package_json, requests_responses)
+    mock_requests.side_effect = registry_failures
+    mock_sleep = mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.sleep"
+    )
+    mock_uniform = mocker.patch(
+        "dd_license_attribution.metadata_collector.strategies."
+        "npm_collection_strategy.uniform",
+        return_value=0.25,
+    )
+
+    strategy = NpmMetadataCollectionStrategy(
+        "package1", source_code_manager_mock, ProjectScope.ALL
+    )
+    initial_metadata = [
+        Metadata(
+            name="package1",
+            origin="https://github.com/org/package1",
+            local_src_path=None,
+            license=[],
+            version=None,
+            copyright=[],
+        ),
+    ]
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Failed to fetch npm registry metadata for dep1@1.0.0 "
+            f"after 3 attempts: {expected_failure}"
+        ),
+    ):
+        strategy.augment_metadata(initial_metadata)
+
+    assert mock_run_command.call_count == 2
+    mock_run_command.assert_any_call(
+        ["npm", "install", "--omit=dev", "--ignore-scripts"],
+        cwd="cache_dir/org_package1",
+    )
+    mock_run_command.assert_any_call(
+        ["npm", "list", "--json", "--omit=dev", "--all"],
+        cwd="cache_dir/org_package1",
+    )
+    mock_output_from_command.assert_not_called()
+    assert mock_exists.call_count == 2  # package.json, yarn.lock
+    assert mock_path_join.call_count == 2  # package.json, yarn.lock
+    assert mock_open.call_count == 1  # package.json
+    assert mock_requests.call_count == 3
+    mock_requests.assert_has_calls(
+        [
+            mock.call("https://registry.npmjs.org/dep1/1.0.0", timeout=5),
+            mock.call("https://registry.npmjs.org/dep1/1.0.0", timeout=5),
+            mock.call("https://registry.npmjs.org/dep1/1.0.0", timeout=5),
+        ]
+    )
+    assert mock_sleep.call_args_list == [mock.call(1.25), mock.call(2.25)]
+    assert mock_uniform.call_args_list == [mock.call(0, 1), mock.call(0, 1)]
 
 
 def test_npm_collection_strategy_handles_npm_install_failure(

--- a/tests/unit/test_npm_collection_strategy.py
+++ b/tests/unit/test_npm_collection_strategy.py
@@ -603,8 +603,9 @@ def test_npm_collection_strategy_handles_missing_root_package(
     assert mock_requests.call_count == 1
 
 
+@pytest.mark.parametrize("retryable_status_code", [408, 429, 501, 599])
 def test_npm_collection_strategy_retries_registry_api_failures(
-    mocker: pytest_mock.MockFixture,
+    mocker: pytest_mock.MockFixture, retryable_status_code: int
 ) -> None:
     source_code_manager_mock = create_source_code_manager_mock()
     package_json: dict[str, Any] = {}
@@ -618,8 +619,9 @@ def test_npm_collection_strategy_retries_registry_api_failures(
 
     requests_responses = [
         mock.Mock(
-            status_code=503,
-            text="Service Unavailable",
+            status_code=retryable_status_code,
+            text="Retryable error",
+            headers={"Retry-After": "5"},
         ),
         mock.Mock(status_code=200, json=lambda: {"license": "MIT", "author": "Alice"}),
         mock.Mock(
@@ -642,7 +644,6 @@ def test_npm_collection_strategy_retries_registry_api_failures(
     mock_uniform = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
         "npm_collection_strategy.uniform",
-        return_value=0.25,
     )
 
     strategy = NpmMetadataCollectionStrategy(
@@ -691,8 +692,8 @@ def test_npm_collection_strategy_retries_registry_api_failures(
             mock.call("https://registry.npmjs.org/dep2/2.0.0", timeout=5),
         ]
     )
-    mock_sleep.assert_called_once_with(1.25)
-    mock_uniform.assert_called_once_with(0, 1)
+    mock_sleep.assert_called_once_with(5)
+    mock_uniform.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -703,9 +704,21 @@ def test_npm_collection_strategy_retries_registry_api_failures(
             requests.exceptions.InvalidURL("invalid registry URL"),
             "invalid registry URL",
         ),
+        (
+            mock.Mock(
+                status_code=503,
+                text="Service Unavailable",
+                headers={"Retry-After": "6"},
+            ),
+            "Retry-After value 6 exceeds the maximum retry delay of 5 seconds",
+        ),
+        (
+            mock.Mock(status_code=600, text="Retry later"),
+            "600, Retry later",
+        ),
     ],
 )
-def test_npm_collection_strategy_aggregates_non_retryable_registry_failures(
+def test_npm_collection_strategy_fails_fast_on_terminal_registry_failure(
     mocker: pytest_mock.MockFixture,
     registry_failure: mock.Mock | requests.RequestException,
     expected_failure: str,
@@ -729,10 +742,7 @@ def test_npm_collection_strategy_aggregates_non_retryable_registry_failures(
         mock_run_command,
         mock_requests,
     ) = setup_npm_strategy_mocks(mocker, package_lock, package_json, requests_responses)
-    mock_requests.side_effect = [
-        registry_failure,
-        mock.Mock(status_code=404, text="Not Found"),
-    ]
+    mock_requests.side_effect = [registry_failure]
 
     strategy = NpmMetadataCollectionStrategy(
         "package1", source_code_manager_mock, ProjectScope.ALL
@@ -748,17 +758,15 @@ def test_npm_collection_strategy_aggregates_non_retryable_registry_failures(
         ),
     ]
 
-    with pytest.raises(RuntimeError) as raised:
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Failed to fetch npm registry metadata for dep1@1.0.0: "
+            f"{expected_failure}"
+        ),
+    ):
         strategy.augment_metadata(initial_metadata)
 
-    assert (
-        "Failed to fetch npm registry metadata for dep1@1.0.0: "
-        f"{expected_failure}" in str(raised.value)
-    )
-    assert (
-        "Failed to fetch npm registry metadata for dep2@2.0.0: 404, Not Found"
-        in str(raised.value)
-    )
     # Verify npm install (via run_command_with_check) and npm list were called
     assert mock_run_command.call_count == 2
     mock_run_command.assert_any_call(
@@ -773,12 +781,8 @@ def test_npm_collection_strategy_aggregates_non_retryable_registry_failures(
     assert mock_exists.call_count == 2  # package.json, yarn.lock
     assert mock_path_join.call_count == 2  # package.json, yarn.lock
     assert mock_open.call_count == 1  # package.json
-    assert mock_requests.call_count == 2
-    mock_requests.assert_has_calls(
-        [
-            mock.call("https://registry.npmjs.org/dep1/1.0.0", timeout=5),
-            mock.call("https://registry.npmjs.org/dep2/2.0.0", timeout=5),
-        ]
+    mock_requests.assert_called_once_with(
+        "https://registry.npmjs.org/dep1/1.0.0", timeout=5
     )
 
 
@@ -798,20 +802,28 @@ def test_npm_collection_strategy_aggregates_non_retryable_registry_failures(
                 mock.Mock(
                     status_code=503,
                     text="Service Unavailable",
-                    headers={},
+                    headers={"Retry-After": "invalid"},
                 ),
                 mock.Mock(
                     status_code=503,
                     text="Service Unavailable",
-                    headers={},
+                    headers={"Retry-After": "invalid"},
                 ),
                 mock.Mock(
                     status_code=503,
                     text="Service Unavailable",
-                    headers={},
+                    headers={"Retry-After": "invalid"},
                 ),
             ],
             "503, Service Unavailable",
+        ),
+        (
+            [
+                requests.exceptions.ChunkedEncodingError("broken response"),
+                requests.exceptions.ChunkedEncodingError("broken response"),
+                requests.exceptions.ChunkedEncodingError("broken response"),
+            ],
+            "broken response",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Transient npm registry errors were converted into empty license and copyright fields, allowing a successful SBOM run to replace valid attribution with incomplete data. This retries temporary network, transfer, and HTTP failures with bounded backoff, jitter, and `Retry-After` handling. Collection stops after the first unresolved dependency and exits before writing a report, so a registry outage cannot multiply the retry budget across the lockfile.