### PR TITLE
chore: pass `secrets.GITHUB_TOKEN` in PR tests, too

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -115,11 +115,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${EVENT_NAME}" = "pull_request" ]; then
-            dd-license-attribution generate-sbom --format spdx --no-gh-auth --use-mirrors=mirrors.json https://github.com/DataDog/dd-license-attribution > ddla-spdx-output.json
-          else
-            dd-license-attribution generate-sbom --format spdx https://github.com/DataDog/dd-license-attribution > ddla-spdx-output.json
-          fi
+          dd-license-attribution generate-sbom --format spdx https://github.com/DataDog/dd-license-attribution > ddla-spdx-output.json
 
           python - <<'PY'
           import json

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -71,10 +71,7 @@ jobs:
           # the matrix Python version; opt out of both by passing false.
           python-version: false
           go-version: false
-          # Pull requests execute code from the branch under test, so do not
-          # expose a token to their dependency-analysis subprocesses. Pushes to
-          # trusted branches keep authentication to avoid API rate limits.
-          github-token: ${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # The SPDX test below runs the CLI directly (not through the action), so
       # it still needs a mirror to scan the PR branch on pull_request events.
@@ -117,7 +114,7 @@ jobs:
         env:
           # The PR branch is untrusted input to dependency analysis. Authenticate
           # only on trusted events; public PR targets do not require a token.
-          GITHUB_TOKEN: ${{ github.event_name != 'pull_request' && secrets.GITHUB_TOKEN || '' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           if [ "${EVENT_NAME}" = "pull_request" ]; then

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -112,8 +112,6 @@ jobs:
       - name: Run the dd-license-attribution script with SPDX output
         if: ${{ matrix.python-version == '3.14' }}
         env:
-          # The PR branch is untrusted input to dependency analysis. Authenticate
-          # only on trusted events; public PR targets do not require a token.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -115,7 +115,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          dd-license-attribution generate-sbom --format spdx https://github.com/DataDog/dd-license-attribution > ddla-spdx-output.json
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            dd-license-attribution generate-sbom --format spdx --use-mirrors=mirrors.json https://github.com/DataDog/dd-license-attribution > ddla-spdx-output.json
+          else
+            dd-license-attribution generate-sbom --format spdx https://github.com/DataDog/dd-license-attribution > ddla-spdx-output.json
+          fi
 
           python - <<'PY'
           import json

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -79,7 +79,7 @@
 "pygmars","https://github.com/aboutcode-org/pygmars","['Apache-2.0']","['nexB. Inc. and others']"
 "pymaven-patch","https://github.com/aboutcode-org/pymaven","['Apache-2']","['Walter Scheper']"
 "pyparsing","https://github.com/pyparsing/pyparsing","['MIT']","['Paul McGuire']"
-"pytz","https://pythonhosted.org/pytz","['MIT']","['Stuart Bishop']"
+"pytz","https://github.com/stub42/pytz","['MIT']","['Stuart Bishop']"
 "rdflib","https://github.com/RDFLib/rdflib","['BSD-3-Clause']","[""Daniel 'eikeon' Krech""]"
 "requests","https://github.com/psf/requests","['Apache-2.0']","['Armin Ronacher', 'Kenneth Reitz']"
 "rich","https://github.com/Textualize/rich","['MIT']","['Will McGugan']"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [X] Bug Fix
- [ ] Documentation Update

## Description

Updated the GitHub Actions workflow to pass the `GITHUB_TOKEN` to the reusable action in order to avoid throttling limits.

## Related tickets & Documents

<!--
For new features or major changes, we follow a documented RFC process (Check our CONTRIBUTING guidelines).
We cannot accept new features or major changes without a linked approved RFC.

For pull requests that relate or close an issue, please include them below.
-->

- Approved RFC (for feature/major changes) #
- Related Issue #
- Closes #

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
