### PR TITLE
fix(action): action/setup-python cache fails for non-python callers

### DIFF
--- a/.ddla-overrides
+++ b/.ddla-overrides
@@ -165,6 +165,23 @@
   {
     "override_type": "replace",
     "target": {
+      "component": "ruff",
+      "origin": "ruff"
+    },
+    "replacement": {
+      "name": "ruff",
+      "origin": "ruff",
+      "license": [
+        "MIT"
+      ],
+      "copyright": [
+        "Charles Marsh"
+      ]
+    }
+  },
+  {
+    "override_type": "replace",
+    "target": {
       "origin": "https://www.crummy.com/software/BeautifulSoup/bs4/"
     },
     "replacement": {

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -83,7 +83,7 @@
 "rdflib","https://github.com/RDFLib/rdflib","['BSD-3-Clause']","[""Daniel 'eikeon' Krech""]"
 "requests","https://github.com/psf/requests","['Apache-2.0']","['Armin Ronacher', 'Kenneth Reitz']"
 "rich","https://github.com/Textualize/rich","['MIT']","['Will McGugan']"
-"ruff","ruff","[]","[]"
+"ruff","ruff","['MIT']","['Charles Marsh']"
 "saneyaml","https://github.com/aboutcode-org/saneyaml","['Apache-2.0']","['nexB. Inc. and others']"
 "scancode-toolkit","https://github.com/aboutcode-org/scancode-toolkit","['Apache-2.0 AND CC-BY-4.0 AND LicenseRef-scancode-other-permissive AND LicenseRef-scancode-other-copyleft']","['nexB. Inc. and others']"
 "semantic-version","https://github.com/rbarrois/python-semanticversion","['BSD']","['Raphaël Barrois']"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -83,6 +83,7 @@
 "rdflib","https://github.com/RDFLib/rdflib","['BSD-3-Clause']","[""Daniel 'eikeon' Krech""]"
 "requests","https://github.com/psf/requests","['Apache-2.0']","['Armin Ronacher', 'Kenneth Reitz']"
 "rich","https://github.com/Textualize/rich","['MIT']","['Will McGugan']"
+"ruff","ruff","[]","[]"
 "saneyaml","https://github.com/aboutcode-org/saneyaml","['Apache-2.0']","['nexB. Inc. and others']"
 "scancode-toolkit","https://github.com/aboutcode-org/scancode-toolkit","['Apache-2.0 AND CC-BY-4.0 AND LicenseRef-scancode-other-permissive AND LicenseRef-scancode-other-copyleft']","['nexB. Inc. and others']"
 "semantic-version","https://github.com/rbarrois/python-semanticversion","['BSD']","['Raphaël Barrois']"

--- a/action.yml
+++ b/action.yml
@@ -187,7 +187,6 @@ runs:
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ inputs.python-version }}
-        cache: "pip"
 
     - name: Set up Go
       if: ${{ inputs.go-version != 'false' && (inputs.gopkg-strategy != 'false' || inputs.ecosystem == 'go') }}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature / Major Change / Refactor / Optimization
- [X] Bug Fix
- [ ] Documentation Update

## Description

Removing `cache: pip` from the `actions/setup-python` step as it breaks for callers that are not Python projects using `pip`, and has limited benefit anyway.

## Related tickets & Documents

See failure in action @ https://github.com/DataDog/dd-iast-go/actions/runs/30998457914/job/92281247498?pr=12

## How to reproduce and testing

<!--
For bug fixes, please describe how you reproduced the issue, what environments this was tested on (architecture, OS, etc.), and how the PR solves the issue.
-->
