### PR TITLE
Harden Rust crate archive handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `generate-sbom-csv` is deprecated in favor of `generate-sbom --format csv`; it still works and emits a deprecation warning.
 
 ### Fixed
+- Fixed Rust crates.io source archive handling by moving download and extraction logic out of OS adaptors and enforcing bounded decompression before extraction.
 - Fixed repeated action invocations overwriting earlier SBOM outputs by creating a unique output file for each invocation.
 - Fixed the action's default tokenless mode failing before a scan because it did not pass `--no-gh-auth` when `github-token` was empty.
 - Fixed the action requiring `csv-path` to exist during structural-only validation with `compare: false`.

--- a/src/dd_license_attribution/adaptors/os.py
+++ b/src/dd_license_attribution/adaptors/os.py
@@ -10,7 +10,8 @@
 import contextlib
 import os
 import subprocess
-from collections.abc import Iterator, Mapping
+import tarfile
+from collections.abc import Iterable, Iterator, Mapping
 
 import requests
 
@@ -108,6 +109,14 @@ def open_file(file_path: str) -> str:
 def write_file(file_path: str, content: str) -> None:
     with open(file_path, "w", encoding="utf-8") as file:
         file.write(content)
+
+
+def extract_tar_members(
+    archive: tarfile.TarFile,
+    members: Iterable[tarfile.TarInfo],
+    destination: str,
+) -> None:
+    archive.extractall(destination, members=members, filter="data")
 
 
 def absolute_path(path: str) -> str:

--- a/src/dd_license_attribution/adaptors/os.py
+++ b/src/dd_license_attribution/adaptors/os.py
@@ -7,21 +7,14 @@
 
 """Here we collect a set of OS wrappers and adaptors to be easily replaced during testing and debugging."""
 
-import io
+import contextlib
 import os
 import subprocess
-import tarfile
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 
 import requests
 
-DDLA_USER_AGENT = (
-    "dd-license-attribution (https://github.com/DataDog/dd-license-attribution)"
-)
-DOWNLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
-MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
-MAX_EXTRACTED_ARCHIVE_BYTES = 100 * 1024 * 1024
-MAX_ARCHIVE_MEMBERS = 10_000
+PATH_SEPARATOR = os.sep
 
 
 def _merge_env(extra: dict[str, str] | None) -> dict[str, str] | None:
@@ -117,141 +110,37 @@ def write_file(file_path: str, content: str) -> None:
         file.write(content)
 
 
-def download_url(
-    url: str,
-    user_agent: str = DDLA_USER_AGENT,
-    max_bytes: int = MAX_DOWNLOAD_BYTES,
-) -> bytes:
-    if max_bytes <= 0:
-        raise ValueError("max_bytes must be greater than zero")
+def absolute_path(path: str) -> str:
+    return os.path.abspath(path)
 
+
+def is_absolute_path(path: str) -> bool:
+    return os.path.isabs(path)
+
+
+@contextlib.contextmanager
+def stream_url(
+    url: str,
+    headers: dict[str, str],
+    chunk_size: int,
+    timeout: int = 30,
+) -> Iterator[tuple[Mapping[str, str], Iterator[bytes]]]:
     response: requests.Response | None = None
     try:
         response = requests.get(
             url,
             allow_redirects=True,
-            headers={"User-Agent": user_agent},
+            headers=headers,
             stream=True,
-            timeout=30,
+            timeout=timeout,
         )
         response.raise_for_status()
-        content_length = response.headers.get("Content-Length")
-        if content_length is not None:
-            try:
-                expected_bytes = int(content_length)
-            except ValueError:
-                expected_bytes = 0
-            if expected_bytes > max_bytes:
-                raise OSError(
-                    f"Download from {url} exceeds maximum size of {max_bytes} bytes"
-                )
-
-        chunks: list[bytes] = []
-        downloaded_bytes = 0
-        for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE_BYTES):
-            if not chunk:
-                continue
-            downloaded_bytes += len(chunk)
-            if downloaded_bytes > max_bytes:
-                raise OSError(
-                    f"Download from {url} exceeds maximum size of {max_bytes} bytes"
-                )
-            chunks.append(chunk)
+        yield response.headers, response.iter_content(chunk_size=chunk_size)
     except requests.RequestException as e:
         raise OSError(f"Failed to download {url}: {e}") from e
     finally:
         if response is not None:
             response.close()
-    return b"".join(chunks)
-
-
-def _is_safe_tar_member(member: tarfile.TarInfo, destination: str) -> bool:
-    if not (member.isfile() or member.isdir()):
-        return False
-
-    if member.issym() or member.islnk():
-        return False
-
-    member_name = member.name.replace("\\", "/")
-    if os.path.isabs(member_name) or ".." in member_name.split("/"):
-        return False
-
-    destination_abs = os.path.abspath(destination)
-    member_target = os.path.abspath(os.path.join(destination_abs, member_name))
-    return member_target == destination_abs or member_target.startswith(
-        f"{destination_abs}{os.sep}"
-    )
-
-
-def extract_tar_gz(
-    archive_content: bytes,
-    destination: str,
-    max_extracted_bytes: int = MAX_EXTRACTED_ARCHIVE_BYTES,
-    max_members: int = MAX_ARCHIVE_MEMBERS,
-) -> list[str]:
-    if max_extracted_bytes <= 0:
-        raise ValueError("max_extracted_bytes must be greater than zero")
-    if max_members <= 0:
-        raise ValueError("max_members must be greater than zero")
-
-    try:
-        with tarfile.open(fileobj=io.BytesIO(archive_content), mode="r:gz") as archive:
-            members = archive.getmembers()
-            if len(members) > max_members:
-                raise ValueError(f"Archive contains more than {max_members} members")
-            unsafe_members = [
-                member.name
-                for member in members
-                if not _is_safe_tar_member(member, destination)
-            ]
-            if unsafe_members:
-                raise ValueError(f"Unsafe archive path: {unsafe_members[0]}")
-
-            extracted_bytes = 0
-            for member in members:
-                if member.isfile() and member.size > max_extracted_bytes:
-                    raise ValueError(
-                        f"Archive member {member.name} exceeds maximum extracted "
-                        f"size of {max_extracted_bytes} bytes"
-                    )
-                extracted_bytes += member.size
-                if extracted_bytes > max_extracted_bytes:
-                    raise ValueError(
-                        "Archive exceeds maximum extracted size "
-                        f"of {max_extracted_bytes} bytes"
-                    )
-
-            archive.extractall(destination, members=members, filter="data")
-            return [member.name for member in members]
-    except tarfile.TarError as e:
-        raise ValueError(f"Malformed gzip tar archive: {e}") from e
-
-
-def read_tar_gz_text_file(
-    archive_content: bytes,
-    member_suffix: str,
-    max_bytes: int = MAX_EXTRACTED_ARCHIVE_BYTES,
-) -> str | None:
-    if max_bytes <= 0:
-        raise ValueError("max_bytes must be greater than zero")
-
-    try:
-        with tarfile.open(fileobj=io.BytesIO(archive_content), mode="r:gz") as archive:
-            for member in archive.getmembers():
-                if not member.isfile() or not member.name.endswith(member_suffix):
-                    continue
-                if member.size > max_bytes:
-                    raise ValueError(
-                        f"Archive member {member.name} exceeds maximum size "
-                        f"of {max_bytes} bytes"
-                    )
-                extracted_file = archive.extractfile(member)
-                if extracted_file is None:
-                    return None
-                return extracted_file.read().decode("utf-8")
-    except tarfile.TarError as e:
-        raise ValueError(f"Malformed gzip tar archive: {e}") from e
-    return None
 
 
 def is_dir(path: str) -> bool:

--- a/src/dd_license_attribution/artifact_management/rust_package_resolver.py
+++ b/src/dd_license_attribution/artifact_management/rust_package_resolver.py
@@ -14,8 +14,6 @@ from urllib.parse import quote
 
 from dd_license_attribution.adaptors.os import (
     create_dirs,
-    download_url,
-    extract_tar_gz,
     format_command_output,
     open_file,
     path_exists,
@@ -28,14 +26,16 @@ from dd_license_attribution.artifact_management.source_code_manager import (
     SourceCodeManager,
     UnauthorizedRepository,
 )
+from dd_license_attribution.utils.bounded_download import (
+    DDLA_USER_AGENT,
+    download_bounded,
+)
+from dd_license_attribution.utils.tar_archive import extract_tar_gz
 
 logger = logging.getLogger("dd_license_attribution")
 
 SYNTHETIC_PACKAGE_NAME = "ddla-rust-resolve"
 LICENSE_TOOL_CONFIG_NAME = "license-tool.toml"
-CRATES_IO_USER_AGENT = (
-    "dd-license-attribution (https://github.com/DataDog/dd-license-attribution)"
-)
 RUST_CARGO_COMMAND_TIMEOUT_SECONDS = 120
 EXACT_VERSION_PATTERN = re.compile(
     r"\d+(?:\.\d+){0,2}(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?"
@@ -330,9 +330,9 @@ class RustPackageResolver:
         )
         try:
             crates_io_metadata: Any = json.loads(
-                download_url(
+                download_bounded(
                     metadata_endpoint,
-                    user_agent=CRATES_IO_USER_AGENT,
+                    user_agent=DDLA_USER_AGENT,
                 )
             )
         except (json.JSONDecodeError, OSError, UnicodeDecodeError) as e:
@@ -402,9 +402,9 @@ class RustPackageResolver:
         create_dirs(source_parent_dir)
 
         try:
-            archive_content = download_url(
+            archive_content = download_bounded(
                 download_endpoint,
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             )
             extracted_members = extract_tar_gz(archive_content, source_parent_dir)
         except (OSError, ValueError) as e:

--- a/src/dd_license_attribution/metadata_collector/strategies/rust_crates_io_collection_strategy.py
+++ b/src/dd_license_attribution/metadata_collector/strategies/rust_crates_io_collection_strategy.py
@@ -12,16 +12,11 @@ import tomllib
 import semver
 
 from dd_license_attribution.adaptors.os import (
-    download_url,
     normalize_path,
     open_file,
     path_exists,
     path_join,
-    read_tar_gz_text_file,
     walk_directory,
-)
-from dd_license_attribution.artifact_management.rust_package_resolver import (
-    CRATES_IO_USER_AGENT,
 )
 from dd_license_attribution.artifact_management.source_code_manager import (
     SourceCodeManager,
@@ -33,6 +28,11 @@ from dd_license_attribution.metadata_collector.strategies.abstract_collection_st
 from dd_license_attribution.metadata_collector.strategies.rust_collection_strategy import (
     is_rust_metadata,
 )
+from dd_license_attribution.utils.bounded_download import (
+    DDLA_USER_AGENT,
+    download_bounded,
+)
+from dd_license_attribution.utils.tar_archive import read_tar_gz_text_file
 
 logger = logging.getLogger("dd_license_attribution")
 
@@ -358,9 +358,9 @@ class RustCratesIoMetadataCollectionStrategy(MetadataCollectionStrategy):
         metadata_url = f"{CRATES_IO_API_BASE_URL}/{crate_name}"
         try:
             response = json.loads(
-                download_url(
+                download_bounded(
                     metadata_url,
-                    user_agent=CRATES_IO_USER_AGENT,
+                    user_agent=DDLA_USER_AGENT,
                 ).decode("utf-8")
             )
         except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
@@ -426,9 +426,9 @@ class RustCratesIoMetadataCollectionStrategy(MetadataCollectionStrategy):
     def _get_crate_authors(self, crate_name: str, version: str) -> list[str]:
         download_endpoint = f"{CRATES_IO_API_BASE_URL}/{crate_name}/{version}/download"
         try:
-            archive_content = download_url(
+            archive_content = download_bounded(
                 download_endpoint,
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             )
             cargo_toml_content = read_tar_gz_text_file(
                 archive_content,

--- a/src/dd_license_attribution/utils/bounded_download.py
+++ b/src/dd_license_attribution/utils/bounded_download.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+from dd_license_attribution.adaptors.os import stream_url
+
+DDLA_USER_AGENT = (
+    "dd-license-attribution (https://github.com/DataDog/dd-license-attribution)"
+)
+DOWNLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
+MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
+
+
+def _exceeds_content_length(content_length: str | None, max_bytes: int) -> bool:
+    if content_length is None:
+        return False
+    try:
+        expected_bytes = int(content_length)
+    except ValueError:
+        return False
+    return expected_bytes > max_bytes
+
+
+def download_bounded(
+    url: str,
+    user_agent: str = DDLA_USER_AGENT,
+    max_bytes: int = MAX_DOWNLOAD_BYTES,
+) -> bytes:
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be greater than zero")
+
+    with stream_url(
+        url,
+        {"User-Agent": user_agent},
+        DOWNLOAD_CHUNK_SIZE_BYTES,
+    ) as (headers, chunks):
+        if _exceeds_content_length(headers.get("Content-Length"), max_bytes):
+            raise OSError(
+                f"Download from {url} exceeds maximum size of {max_bytes} bytes"
+            )
+
+        buffer: list[bytes] = []
+        downloaded_bytes = 0
+        for chunk in chunks:
+            if not chunk:
+                continue
+            downloaded_bytes += len(chunk)
+            if downloaded_bytes > max_bytes:
+                raise OSError(
+                    f"Download from {url} exceeds maximum size of {max_bytes} bytes"
+                )
+            buffer.append(chunk)
+    return b"".join(buffer)

--- a/src/dd_license_attribution/utils/tar_archive.py
+++ b/src/dd_license_attribution/utils/tar_archive.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+import contextlib
+import gzip
+import io
+import tarfile
+from collections.abc import Iterator
+
+from dd_license_attribution.adaptors.os import (
+    PATH_SEPARATOR,
+    absolute_path,
+    is_absolute_path,
+    path_join,
+)
+
+MAX_EXTRACTED_ARCHIVE_BYTES = 100 * 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 10_000
+_TAR_BLOCK_SIZE = 512
+_MAX_DELEGATED_READ_BYTES = 1024 * 1024
+
+
+class _BoundedGzipReader(io.RawIOBase):
+    """Caps how far tarfile may advance into the decompressed gzip stream."""
+
+    def __init__(
+        self,
+        raw: gzip.GzipFile,
+        max_bytes: int,
+        max_content_bytes: int,
+    ) -> None:
+        self._raw = raw
+        self._max_bytes = max_bytes
+        self._max_content_bytes = max_content_bytes
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def tell(self) -> int:
+        return self._raw.tell()
+
+    def read(self, size: int = -1) -> bytes:
+        delegated_size = self._bounded_read_size(size)
+        content = self._raw.read(delegated_size)
+        self._check_budget()
+        return content
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        current_position = self._raw.tell()
+        target_position = self._target_position(offset, whence, current_position)
+        if target_position < current_position:
+            position = self._raw.seek(target_position, io.SEEK_SET)
+            self._check_budget()
+            return position
+
+        bytes_to_skip = target_position - current_position
+        while bytes_to_skip > 0:
+            chunk = self.read(min(bytes_to_skip, _MAX_DELEGATED_READ_BYTES))
+            if not chunk:
+                break
+            bytes_to_skip -= len(chunk)
+        position = self._raw.tell()
+        self._check_budget()
+        return position
+
+    def _bounded_read_size(self, requested_size: int) -> int:
+        remaining_bytes = self._max_bytes - self._raw.tell()
+        if remaining_bytes < 0:
+            self._check_budget()
+        if requested_size < 0 or requested_size > remaining_bytes:
+            return remaining_bytes + 1
+        return requested_size
+
+    def _target_position(
+        self,
+        offset: int,
+        whence: int,
+        current_position: int,
+    ) -> int:
+        if whence == io.SEEK_SET:
+            return offset
+        if whence == io.SEEK_CUR:
+            return current_position + offset
+        if whence == io.SEEK_END:
+            raise ValueError("Seeking from end is not supported for gzip tar archives")
+        raise ValueError(f"Invalid seek mode: {whence}")
+
+    def _check_budget(self) -> None:
+        if self._raw.tell() > self._max_bytes:
+            raise ValueError(
+                "Archive exceeds maximum extracted size "
+                f"of {self._max_content_bytes} bytes"
+            )
+
+
+def _decompression_budget(max_content_bytes: int, max_members: int) -> int:
+    """Content allowance plus tar header and padding overhead."""
+    return max_content_bytes + (max_members + 2) * 2 * _TAR_BLOCK_SIZE
+
+
+@contextlib.contextmanager
+def _open_bounded_tar_gz(
+    archive_content: bytes,
+    budget: int,
+    max_content_bytes: int,
+) -> Iterator[tarfile.TarFile]:
+    try:
+        with gzip.GzipFile(fileobj=io.BytesIO(archive_content)) as gzip_stream:
+            reader = _BoundedGzipReader(gzip_stream, budget, max_content_bytes)
+            with tarfile.open(fileobj=reader, mode="r:") as archive:
+                yield archive
+    except (tarfile.TarError, gzip.BadGzipFile, EOFError) as e:
+        raise ValueError(f"Malformed gzip tar archive: {e}") from e
+
+
+def _is_safe_tar_member(member: tarfile.TarInfo, destination: str) -> bool:
+    if not (member.isfile() or member.isdir()):
+        return False
+
+    member_name = member.name.replace("\\", "/")
+    if is_absolute_path(member_name) or ".." in member_name.split("/"):
+        return False
+
+    destination_abs = absolute_path(destination)
+    member_target = absolute_path(path_join(destination_abs, member_name))
+    return member_target == destination_abs or member_target.startswith(
+        f"{destination_abs}{PATH_SEPARATOR}"
+    )
+
+
+def _iter_validated_members(
+    archive: tarfile.TarFile,
+    destination: str,
+    max_extracted_bytes: int,
+    max_members: int,
+) -> Iterator[tarfile.TarInfo]:
+    member_count = 0
+    extracted_bytes = 0
+    for member in archive:
+        member_count += 1
+        if member_count > max_members:
+            raise ValueError(f"Archive contains more than {max_members} members")
+        if not _is_safe_tar_member(member, destination):
+            raise ValueError(f"Unsafe archive path: {member.name}")
+        if member.isfile() and member.size > max_extracted_bytes:
+            raise ValueError(
+                f"Archive member {member.name} exceeds maximum extracted "
+                f"size of {max_extracted_bytes} bytes"
+            )
+        extracted_bytes += member.size
+        if extracted_bytes > max_extracted_bytes:
+            raise ValueError(
+                "Archive exceeds maximum extracted size "
+                f"of {max_extracted_bytes} bytes"
+            )
+        yield member
+
+
+def extract_tar_gz(
+    archive_content: bytes,
+    destination: str,
+    max_extracted_bytes: int = MAX_EXTRACTED_ARCHIVE_BYTES,
+    max_members: int = MAX_ARCHIVE_MEMBERS,
+) -> list[str]:
+    if max_extracted_bytes <= 0:
+        raise ValueError("max_extracted_bytes must be greater than zero")
+    if max_members <= 0:
+        raise ValueError("max_members must be greater than zero")
+
+    budget = _decompression_budget(max_extracted_bytes, max_members)
+    with _open_bounded_tar_gz(archive_content, budget, max_extracted_bytes) as archive:
+        member_names = [
+            member.name
+            for member in _iter_validated_members(
+                archive,
+                destination,
+                max_extracted_bytes,
+                max_members,
+            )
+        ]
+
+    with _open_bounded_tar_gz(archive_content, budget, max_extracted_bytes) as archive:
+        for member in _iter_validated_members(
+            archive,
+            destination,
+            max_extracted_bytes,
+            max_members,
+        ):
+            archive.extract(member, destination, filter="data")
+
+    return member_names
+
+
+def read_tar_gz_text_file(
+    archive_content: bytes,
+    member_suffix: str,
+    max_bytes: int = MAX_EXTRACTED_ARCHIVE_BYTES,
+    max_members: int = MAX_ARCHIVE_MEMBERS,
+) -> str | None:
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be greater than zero")
+    if max_members <= 0:
+        raise ValueError("max_members must be greater than zero")
+
+    budget = _decompression_budget(max_bytes, max_members)
+    with _open_bounded_tar_gz(archive_content, budget, max_bytes) as archive:
+        member_count = 0
+        for member in archive:
+            member_count += 1
+            if member_count > max_members:
+                raise ValueError(f"Archive contains more than {max_members} members")
+            if not member.isfile() or not member.name.endswith(member_suffix):
+                continue
+            if member.size > max_bytes:
+                raise ValueError(
+                    f"Archive member {member.name} exceeds maximum size "
+                    f"of {max_bytes} bytes"
+                )
+            extracted_file = archive.extractfile(member)
+            if extracted_file is None:
+                return None
+            return extracted_file.read().decode("utf-8")
+    return None

--- a/src/dd_license_attribution/utils/tar_archive.py
+++ b/src/dd_license_attribution/utils/tar_archive.py
@@ -14,6 +14,7 @@ from collections.abc import Iterator
 from dd_license_attribution.adaptors.os import (
     PATH_SEPARATOR,
     absolute_path,
+    extract_tar_members,
     is_absolute_path,
     path_join,
 )
@@ -187,13 +188,16 @@ def extract_tar_gz(
         ]
 
     with _open_bounded_tar_gz(archive_content, budget, max_extracted_bytes) as archive:
-        for member in _iter_validated_members(
+        extract_tar_members(
             archive,
+            _iter_validated_members(
+                archive,
+                destination,
+                max_extracted_bytes,
+                max_members,
+            ),
             destination,
-            max_extracted_bytes,
-            max_members,
-        ):
-            archive.extract(member, destination, filter="data")
+        )
 
     return member_names
 

--- a/tests/contract/test_agithub.py
+++ b/tests/contract/test_agithub.py
@@ -16,9 +16,31 @@ Consider marking them to run separately from unit tests if needed.
 """
 
 import os
+from typing import Protocol
 
 import pytest
 from agithub.GitHub import GitHub
+
+
+class _GitHubGetEndpoint(Protocol):
+    def get(self) -> tuple[int, object]: ...
+
+
+def _get_from_github_api(endpoint: _GitHubGetEndpoint) -> tuple[int, object]:
+    try:
+        return endpoint.get()
+    except OSError as exc:
+        pytest.skip("GitHub API is unavailable: {error}".format(error=exc))
+
+
+def _skip_if_github_api_unavailable(status: int, result: object) -> None:
+    if 500 <= status < 600:
+        pytest.skip(
+            "GitHub API returned server error {status}: {result}".format(
+                status=status,
+                result=result,
+            )
+        )
 
 
 @pytest.fixture
@@ -39,7 +61,10 @@ def test_repos_get_returns_expected_structure(github_client: GitHub) -> None:
     We depend on: owner, license, html_url, url fields from the API response.
     """
     # Use DataDog/dd-license-attribution as a known public repository
-    status, result = github_client.repos["DataDog"]["dd-license-attribution"].get()
+    status, result = _get_from_github_api(
+        github_client.repos["DataDog"]["dd-license-attribution"]
+    )
+    _skip_if_github_api_unavailable(status, result)
 
     # Validate successful response
     assert status == 200, f"Expected status 200, got {status}"
@@ -73,7 +98,8 @@ def test_repos_get_handles_redirects(github_client: GitHub) -> None:
     from urllib.parse import urlparse
 
     # Test with DataDog/ospo-tools which was renamed to DataDog/dd-license-attribution
-    status, result = github_client.repos["DataDog"]["ospo-tools"].get()
+    status, result = _get_from_github_api(github_client.repos["DataDog"]["ospo-tools"])
+    _skip_if_github_api_unavailable(status, result)
 
     # Should receive a 301 redirect
     assert status == 301, f"Expected status 301 for renamed repo, got {status}"
@@ -93,7 +119,10 @@ def test_repos_get_handles_redirects(github_client: GitHub) -> None:
 
 def test_repos_get_handles_404_error(github_client: GitHub) -> None:
     """Ensure repos.get() returns 404 for non-existent repositories."""
-    status, result = github_client.repos["NonExistentOwner"]["NonExistentRepo"].get()
+    status, result = _get_from_github_api(
+        github_client.repos["NonExistentOwner"]["NonExistentRepo"]
+    )
+    _skip_if_github_api_unavailable(status, result)
 
     assert status == 404, f"Expected status 404 for non-existent repo, got {status}"
 
@@ -106,9 +135,13 @@ def test_dependency_graph_sbom_get_returns_expected_structure(
     We depend on: sbom.packages field with name, SPDXID in package data.
     """
     # Use DataDog/dd-license-attribution as a known public repository with dependencies
-    status, result = github_client.repos["DataDog"]["dd-license-attribution"][
-        "dependency-graph"
-    ].sbom.get()
+    status, result = _get_from_github_api(
+        github_client.repos["DataDog"]["dd-license-attribution"][
+            "dependency-graph"
+        ].sbom
+    )
+
+    _skip_if_github_api_unavailable(status, result)
 
     if status == 404:
         pytest.skip(
@@ -143,9 +176,12 @@ def test_dependency_graph_sbom_get_returns_expected_structure(
 def test_dependency_graph_sbom_get_handles_404(github_client: GitHub) -> None:
     """Ensure dependency-graph.sbom.get() returns 404 for repos without access/SBOM."""
     # Use a non-existent repository
-    status, result = github_client.repos["NonExistentOwner"]["NonExistentRepo"][
-        "dependency-graph"
-    ].sbom.get()
+    status, result = _get_from_github_api(
+        github_client.repos["NonExistentOwner"]["NonExistentRepo"][
+            "dependency-graph"
+        ].sbom
+    )
+    _skip_if_github_api_unavailable(status, result)
 
     assert status == 404, f"Expected status 404 for non-existent repo, got {status}"
 

--- a/tests/contract/test_tar_archive.py
+++ b/tests/contract/test_tar_archive.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+import io
+import tarfile
+from pathlib import Path
+
+from dd_license_attribution.utils.tar_archive import extract_tar_gz
+
+
+def _tar_gz_with_files(files: dict[str, bytes]) -> bytes:
+    archive_bytes = io.BytesIO()
+    with tarfile.open(fileobj=archive_bytes, mode="w:gz") as archive:
+        for name, content in files.items():
+            member = tarfile.TarInfo(name)
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+    return archive_bytes.getvalue()
+
+
+def _tar_gz_with_read_only_directory() -> bytes:
+    archive_bytes = io.BytesIO()
+    with tarfile.open(fileobj=archive_bytes, mode="w:gz") as archive:
+        directory = tarfile.TarInfo("crate")
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o500
+        archive.addfile(directory)
+
+        member = tarfile.TarInfo("crate/Cargo.toml")
+        content = b"[package]\n"
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+    return archive_bytes.getvalue()
+
+
+def test_extract_tar_gz_extracts_members_to_destination(tmp_path: Path) -> None:
+    archive_content = _tar_gz_with_files(
+        {
+            "demo-1.2.3/Cargo.toml": b"[package]\n",
+            "demo-1.2.3/src/lib.rs": b"pub fn demo() {}\n",
+        }
+    )
+
+    result = extract_tar_gz(archive_content, str(tmp_path))
+
+    assert result == ["demo-1.2.3/Cargo.toml", "demo-1.2.3/src/lib.rs"]
+    assert (tmp_path / "demo-1.2.3" / "Cargo.toml").read_bytes() == b"[package]\n"
+    assert (
+        tmp_path / "demo-1.2.3" / "src" / "lib.rs"
+    ).read_bytes() == b"pub fn demo() {}\n"
+
+
+def test_extract_tar_gz_defers_directory_permissions_until_children_are_extracted(
+    tmp_path: Path,
+) -> None:
+    archive_content = _tar_gz_with_read_only_directory()
+    directory_path = tmp_path / "crate"
+
+    try:
+        result = extract_tar_gz(archive_content, str(tmp_path))
+
+        assert result == ["crate", "crate/Cargo.toml"]
+        assert (directory_path / "Cargo.toml").read_bytes() == b"[package]\n"
+    finally:
+        if directory_path.exists():
+            directory_path.chmod(0o700)

--- a/tests/unit/test_bounded_download.py
+++ b/tests/unit/test_bounded_download.py
@@ -136,9 +136,34 @@ def test_download_bounded_rejects_cumulative_stream_over_limit(
     assert consumed.call_count == 2
 
 
+def test_download_bounded_accepts_single_byte_limit(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    chunks, consumed = _tracked_chunks([b"x"])
+    mock_stream_url = mocker.patch(
+        "dd_license_attribution.utils.bounded_download.stream_url",
+        return_value=contextlib.nullcontext(({}, chunks)),
+    )
+
+    result = download_bounded(
+        "https://example.test/crate/download",
+        user_agent="test-agent",
+        max_bytes=1,
+    )
+
+    assert result == b"x"
+    mock_stream_url.assert_called_once_with(
+        "https://example.test/crate/download",
+        {"User-Agent": "test-agent"},
+        DOWNLOAD_CHUNK_SIZE_BYTES,
+    )
+    consumed.assert_called_once_with(b"x")
+
+
 def test_download_bounded_rejects_invalid_size_limit() -> None:
-    with pytest.raises(ValueError, match="max_bytes must be greater than zero"):
+    with pytest.raises(ValueError) as exc_info:
         download_bounded("https://example.test/crate/download", max_bytes=0)
+    assert str(exc_info.value) == "max_bytes must be greater than zero"
 
 
 def test_download_bounded_propagates_stream_url_oserror(

--- a/tests/unit/test_bounded_download.py
+++ b/tests/unit/test_bounded_download.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+import contextlib
+from collections.abc import Iterator
+from unittest.mock import Mock
+
+import pytest
+import pytest_mock
+
+from dd_license_attribution.utils.bounded_download import (
+    DDLA_USER_AGENT,
+    DOWNLOAD_CHUNK_SIZE_BYTES,
+    MAX_DOWNLOAD_BYTES,
+    _exceeds_content_length,
+    download_bounded,
+)
+
+
+def _tracked_chunks(chunks: list[bytes]) -> tuple[Iterator[bytes], Mock]:
+    consumed = Mock()
+
+    def iterator() -> Iterator[bytes]:
+        for chunk in chunks:
+            consumed(chunk)
+            yield chunk
+
+    return iterator(), consumed
+
+
+def test_download_bounded_joins_non_empty_chunks(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    chunks, consumed = _tracked_chunks([b"crate", b"", b" archive"])
+    mock_stream_url = mocker.patch(
+        "dd_license_attribution.utils.bounded_download.stream_url",
+        return_value=contextlib.nullcontext(({}, chunks)),
+    )
+
+    result = download_bounded(
+        "https://example.test/crate/download",
+        user_agent="test-agent",
+        max_bytes=20,
+    )
+
+    assert result == b"crate archive"
+    mock_stream_url.assert_called_once_with(
+        "https://example.test/crate/download",
+        {"User-Agent": "test-agent"},
+        DOWNLOAD_CHUNK_SIZE_BYTES,
+    )
+    consumed.assert_any_call(b"crate")
+    consumed.assert_any_call(b"")
+    consumed.assert_any_call(b" archive")
+    assert consumed.call_count == 3
+
+
+def test_download_bounded_rejects_content_length_over_limit_without_reading_chunks(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    chunks, consumed = _tracked_chunks([b"crate"])
+    mock_stream_url = mocker.patch(
+        "dd_license_attribution.utils.bounded_download.stream_url",
+        return_value=contextlib.nullcontext(({"Content-Length": "21"}, chunks)),
+    )
+
+    with pytest.raises(OSError, match="exceeds maximum size"):
+        download_bounded(
+            "https://example.test/crate/download",
+            user_agent="test-agent",
+            max_bytes=20,
+        )
+
+    mock_stream_url.assert_called_once_with(
+        "https://example.test/crate/download",
+        {"User-Agent": "test-agent"},
+        DOWNLOAD_CHUNK_SIZE_BYTES,
+    )
+    consumed.assert_not_called()
+
+
+@pytest.mark.parametrize("content_length", [None, "not-a-number"])
+def test_download_bounded_ignores_absent_or_invalid_content_length(
+    mocker: pytest_mock.MockFixture,
+    content_length: str | None,
+) -> None:
+    chunks, consumed = _tracked_chunks([b"crate"])
+    headers = {} if content_length is None else {"Content-Length": content_length}
+    mock_stream_url = mocker.patch(
+        "dd_license_attribution.utils.bounded_download.stream_url",
+        return_value=contextlib.nullcontext((headers, chunks)),
+    )
+
+    result = download_bounded(
+        "https://example.test/crate/download",
+        user_agent="test-agent",
+        max_bytes=20,
+    )
+
+    assert result == b"crate"
+    mock_stream_url.assert_called_once_with(
+        "https://example.test/crate/download",
+        {"User-Agent": "test-agent"},
+        DOWNLOAD_CHUNK_SIZE_BYTES,
+    )
+    consumed.assert_called_once_with(b"crate")
+
+
+def test_download_bounded_rejects_cumulative_stream_over_limit(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    chunks, consumed = _tracked_chunks([b"crate", b" archive"])
+    mock_stream_url = mocker.patch(
+        "dd_license_attribution.utils.bounded_download.stream_url",
+        return_value=contextlib.nullcontext(({}, chunks)),
+    )
+
+    with pytest.raises(OSError, match="exceeds maximum size"):
+        download_bounded(
+            "https://example.test/crate/download",
+            user_agent="test-agent",
+            max_bytes=10,
+        )
+
+    mock_stream_url.assert_called_once_with(
+        "https://example.test/crate/download",
+        {"User-Agent": "test-agent"},
+        DOWNLOAD_CHUNK_SIZE_BYTES,
+    )
+    consumed.assert_any_call(b"crate")
+    consumed.assert_any_call(b" archive")
+    assert consumed.call_count == 2
+
+
+def test_download_bounded_rejects_invalid_size_limit() -> None:
+    with pytest.raises(ValueError, match="max_bytes must be greater than zero"):
+        download_bounded("https://example.test/crate/download", max_bytes=0)
+
+
+def test_download_bounded_propagates_stream_url_oserror(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    mock_stream_url = mocker.patch(
+        "dd_license_attribution.utils.bounded_download.stream_url",
+        side_effect=OSError("network unavailable"),
+    )
+
+    with pytest.raises(OSError, match="network unavailable"):
+        download_bounded(
+            "https://example.test/crate/download",
+            user_agent="test-agent",
+        )
+
+    mock_stream_url.assert_called_once_with(
+        "https://example.test/crate/download",
+        {"User-Agent": "test-agent"},
+        DOWNLOAD_CHUNK_SIZE_BYTES,
+    )
+
+
+def test_exceeds_content_length_parsing() -> None:
+    assert _exceeds_content_length("21", 20)
+    assert not _exceeds_content_length("20", 20)
+    assert not _exceeds_content_length("not-a-number", 20)
+    assert not _exceeds_content_length(None, 20)
+
+
+def test_download_constants_are_pinned() -> None:
+    assert DDLA_USER_AGENT == (
+        "dd-license-attribution (https://github.com/DataDog/dd-license-attribution)"
+    )
+    assert DOWNLOAD_CHUNK_SIZE_BYTES == 1024 * 1024
+    assert MAX_DOWNLOAD_BYTES == 100 * 1024 * 1024

--- a/tests/unit/test_os_adaptor.py
+++ b/tests/unit/test_os_adaptor.py
@@ -5,9 +5,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2026-present Datadog, Inc.
 
-import io
 import subprocess
-import tarfile
+from collections.abc import Iterator
 from unittest.mock import Mock
 
 import pytest
@@ -15,145 +14,114 @@ import pytest_mock
 import requests
 
 from dd_license_attribution.adaptors.os import (
-    DOWNLOAD_CHUNK_SIZE_BYTES,
-    download_url,
-    extract_tar_gz,
+    absolute_path,
     get_env_var,
+    is_absolute_path,
     normalize_path,
-    read_tar_gz_text_file,
     run_command,
     run_command_with_check,
+    stream_url,
 )
 
 
 def _mock_response(chunks: list[bytes], headers: dict[str, str] | None = None) -> Mock:
     response = Mock()
     response.headers = headers or {}
-    response.iter_content.return_value = chunks
+    response.iter_content.return_value = iter(chunks)
     return response
 
 
-def _assert_download_request(mock_get: Mock, url: str, user_agent: str) -> None:
+def _assert_stream_request(mock_get: Mock, url: str, headers: dict[str, str]) -> None:
     mock_get.assert_called_once_with(
         url,
         allow_redirects=True,
-        headers={"User-Agent": user_agent},
+        headers=headers,
         stream=True,
         timeout=30,
     )
 
 
-def _tar_gz_with_member(member: tarfile.TarInfo) -> bytes:
-    archive_bytes = io.BytesIO()
-    with tarfile.open(fileobj=archive_bytes, mode="w:gz") as archive:
-        archive.addfile(member)
-    return archive_bytes.getvalue()
-
-
-def _tar_gz_with_files(files: dict[str, bytes]) -> bytes:
-    archive_bytes = io.BytesIO()
-    with tarfile.open(fileobj=archive_bytes, mode="w:gz") as archive:
-        for name, content in files.items():
-            member = tarfile.TarInfo(name)
-            member.size = len(content)
-            archive.addfile(member, io.BytesIO(content))
-    return archive_bytes.getvalue()
-
-
-def test_download_url_streams_response_and_closes(
+def test_stream_url_yields_headers_and_chunks_then_closes(
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    response = _mock_response([b"crate", b"", b" archive"])
+    response = _mock_response(
+        [b"crate", b" archive"],
+        headers={"Content-Length": "13"},
+    )
     mock_get = mocker.patch(
         "dd_license_attribution.adaptors.os.requests.get",
         return_value=response,
     )
 
-    result = download_url(
+    with stream_url(
         "https://example.test/crate/download",
-        user_agent="test-agent",
-        max_bytes=20,
-    )
+        {"User-Agent": "test-agent"},
+        1024,
+    ) as (headers, chunks):
+        result = b"".join(chunks)
 
+    assert headers == {"Content-Length": "13"}
     assert result == b"crate archive"
-    _assert_download_request(
+    _assert_stream_request(
         mock_get,
         "https://example.test/crate/download",
-        "test-agent",
+        {"User-Agent": "test-agent"},
     )
     response.raise_for_status.assert_called_once_with()
-    response.iter_content.assert_called_once_with(chunk_size=DOWNLOAD_CHUNK_SIZE_BYTES)
+    response.iter_content.assert_called_once_with(chunk_size=1024)
     response.close.assert_called_once_with()
 
 
-def test_download_url_rejects_content_length_over_limit(
+def test_stream_url_closes_response_when_body_iteration_fails(
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    response = _mock_response([], headers={"Content-Length": "21"})
+    def failing_chunks() -> Iterator[bytes]:
+        raise requests.ConnectionError("connection lost")
+        yield b"unreachable"
+
+    response = _mock_response([])
+    response.iter_content.return_value = failing_chunks()
     mock_get = mocker.patch(
         "dd_license_attribution.adaptors.os.requests.get",
         return_value=response,
     )
 
-    with pytest.raises(OSError, match="exceeds maximum size"):
-        download_url(
+    with pytest.raises(OSError, match="Failed to download"):
+        with stream_url(
             "https://example.test/crate/download",
-            user_agent="test-agent",
-            max_bytes=20,
-        )
+            {"User-Agent": "test-agent"},
+            1024,
+        ) as (_, chunks):
+            b"".join(chunks)
 
-    _assert_download_request(
+    _assert_stream_request(
         mock_get,
         "https://example.test/crate/download",
-        "test-agent",
+        {"User-Agent": "test-agent"},
     )
     response.raise_for_status.assert_called_once_with()
-    response.iter_content.assert_not_called()
+    response.iter_content.assert_called_once_with(chunk_size=1024)
     response.close.assert_called_once_with()
 
 
-def test_download_url_rejects_stream_over_limit(
-    mocker: pytest_mock.MockFixture,
-) -> None:
-    response = _mock_response([b"crate", b" archive"])
-    mock_get = mocker.patch(
-        "dd_license_attribution.adaptors.os.requests.get",
-        return_value=response,
-    )
-
-    with pytest.raises(OSError, match="exceeds maximum size"):
-        download_url(
-            "https://example.test/crate/download",
-            user_agent="test-agent",
-            max_bytes=10,
-        )
-
-    _assert_download_request(
-        mock_get,
-        "https://example.test/crate/download",
-        "test-agent",
-    )
-    response.raise_for_status.assert_called_once_with()
-    response.iter_content.assert_called_once_with(chunk_size=DOWNLOAD_CHUNK_SIZE_BYTES)
-    response.close.assert_called_once_with()
-
-
-def test_download_url_wraps_request_errors(mocker: pytest_mock.MockFixture) -> None:
+def test_stream_url_wraps_request_errors(mocker: pytest_mock.MockFixture) -> None:
     mock_get = mocker.patch(
         "dd_license_attribution.adaptors.os.requests.get",
         side_effect=requests.Timeout("timed out"),
     )
 
     with pytest.raises(OSError, match="Failed to download"):
-        download_url(
+        with stream_url(
             "https://example.test/crate/download",
-            user_agent="test-agent",
-        )
+            {"User-Agent": "test-agent"},
+            1024,
+        ):
+            pass
 
-    _assert_download_request(
+    _assert_stream_request(
         mock_get,
         "https://example.test/crate/download",
-        "test-agent",
+        {"User-Agent": "test-agent"},
     )
 
 
@@ -171,150 +139,30 @@ def test_get_env_var_returns_environment_value(
     mock_environ_get.assert_called_once_with("CI")
 
 
-@pytest.mark.parametrize(
-    "member_type",
-    [
-        tarfile.FIFOTYPE,
-        tarfile.CHRTYPE,
-        tarfile.BLKTYPE,
-    ],
-)
-def test_extract_tar_gz_rejects_special_members(member_type: bytes) -> None:
-    member = tarfile.TarInfo("crate/special")
-    member.type = member_type
-    archive_content = _tar_gz_with_member(member)
-
-    with pytest.raises(ValueError, match="Unsafe archive path: crate/special"):
-        extract_tar_gz(archive_content, "/destination")
-
-
-@pytest.mark.parametrize(
-    "member_name",
-    [
-        "../escape.txt",
-        "crate/../../escape.txt",
-        "/tmp/escape.txt",
-        "crate\\..\\escape.txt",
-    ],
-)
-def test_extract_tar_gz_rejects_unsafe_member_paths(member_name: str) -> None:
-    member = tarfile.TarInfo(member_name)
-    member.size = 0
-    archive_content = _tar_gz_with_member(member)
-
-    with pytest.raises(ValueError, match="Unsafe archive path"):
-        extract_tar_gz(archive_content, "/destination")
-
-
-@pytest.mark.parametrize("member_type", [tarfile.SYMTYPE, tarfile.LNKTYPE])
-def test_extract_tar_gz_rejects_link_members(member_type: bytes) -> None:
-    member = tarfile.TarInfo("crate/link")
-    member.type = member_type
-    member.linkname = "../escape.txt"
-    archive_content = _tar_gz_with_member(member)
-
-    with pytest.raises(ValueError, match="Unsafe archive path: crate/link"):
-        extract_tar_gz(archive_content, "/destination")
-
-
-def test_extract_tar_gz_rejects_too_many_members() -> None:
-    archive_content = _tar_gz_with_files(
-        {
-            "crate/one.txt": b"one",
-            "crate/two.txt": b"two",
-        }
+def test_absolute_path_returns_os_absolute_path(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    mock_abspath = mocker.patch(
+        "dd_license_attribution.adaptors.os.os.path.abspath",
+        return_value="/project/file.txt",
     )
 
-    with pytest.raises(ValueError, match="Archive contains more than 1 members"):
-        extract_tar_gz(archive_content, "/destination", max_members=1)
+    result = absolute_path("file.txt")
+
+    assert result == "/project/file.txt"
+    mock_abspath.assert_called_once_with("file.txt")
 
 
-def test_extract_tar_gz_rejects_invalid_member_limit() -> None:
-    with pytest.raises(ValueError, match="max_members must be greater than zero"):
-        extract_tar_gz(b"archive", "/destination", max_members=0)
-
-
-def test_extract_tar_gz_rejects_file_over_extracted_size_limit() -> None:
-    archive_content = _tar_gz_with_files({"crate/large.txt": b"x" * 21})
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Archive member crate/large.txt exceeds maximum extracted size "
-            "of 20 bytes"
-        ),
-    ):
-        extract_tar_gz(
-            archive_content,
-            "/destination",
-            max_extracted_bytes=20,
-        )
-
-
-def test_extract_tar_gz_rejects_total_extracted_size_over_limit() -> None:
-    archive_content = _tar_gz_with_files(
-        {
-            "crate/one.txt": b"x" * 10,
-            "crate/two.txt": b"y" * 11,
-        }
+def test_is_absolute_path_returns_os_result(mocker: pytest_mock.MockFixture) -> None:
+    mock_isabs = mocker.patch(
+        "dd_license_attribution.adaptors.os.os.path.isabs",
+        return_value=True,
     )
 
-    with pytest.raises(
-        ValueError,
-        match="Archive exceeds maximum extracted size of 20 bytes",
-    ):
-        extract_tar_gz(
-            archive_content,
-            "/destination",
-            max_extracted_bytes=20,
-        )
+    result = is_absolute_path("/project/file.txt")
 
-
-def test_extract_tar_gz_rejects_malformed_archive() -> None:
-    with pytest.raises(ValueError, match="Malformed gzip tar archive"):
-        extract_tar_gz(b"not a gzip tar archive", "/destination")
-
-
-def test_read_tar_gz_text_file_reads_matching_member() -> None:
-    archive_content = _tar_gz_with_files(
-        {
-            "crate/README.md": b"readme",
-            "crate/Cargo.toml": b'[package]\nname = "crate"\n',
-        }
-    )
-
-    result = read_tar_gz_text_file(archive_content, "/Cargo.toml")
-
-    assert result == '[package]\nname = "crate"\n'
-
-
-def test_read_tar_gz_text_file_returns_none_without_matching_member() -> None:
-    archive_content = _tar_gz_with_files({"crate/README.md": b"readme"})
-
-    result = read_tar_gz_text_file(archive_content, "/Cargo.toml")
-
-    assert result is None
-
-
-def test_read_tar_gz_text_file_rejects_oversized_member() -> None:
-    archive_content = _tar_gz_with_files({"crate/Cargo.toml": b"x" * 21})
-
-    with pytest.raises(ValueError, match="exceeds maximum size of 20 bytes"):
-        read_tar_gz_text_file(
-            archive_content,
-            "/Cargo.toml",
-            max_bytes=20,
-        )
-
-
-def test_read_tar_gz_text_file_rejects_invalid_size_limit() -> None:
-    with pytest.raises(ValueError, match="max_bytes must be greater than zero"):
-        read_tar_gz_text_file(b"archive", "/Cargo.toml", max_bytes=0)
-
-
-def test_read_tar_gz_text_file_rejects_malformed_archive() -> None:
-    with pytest.raises(ValueError, match="Malformed gzip tar archive"):
-        read_tar_gz_text_file(b"not a gzip tar archive", "/Cargo.toml")
+    assert result is True
+    mock_isabs.assert_called_once_with("/project/file.txt")
 
 
 def test_normalize_path_collapses_relative_segments() -> None:

--- a/tests/unit/test_os_adaptor.py
+++ b/tests/unit/test_os_adaptor.py
@@ -6,6 +6,7 @@
 # Copyright 2026-present Datadog, Inc.
 
 import subprocess
+import tarfile
 from collections.abc import Iterator
 from unittest.mock import Mock
 
@@ -15,6 +16,7 @@ import requests
 
 from dd_license_attribution.adaptors.os import (
     absolute_path,
+    extract_tar_members,
     get_env_var,
     is_absolute_path,
     normalize_path,
@@ -137,6 +139,19 @@ def test_get_env_var_returns_environment_value(
 
     assert result == "true"
     mock_environ_get.assert_called_once_with("CI")
+
+
+def test_extract_tar_members_delegates_to_extractall() -> None:
+    archive = Mock(spec=tarfile.TarFile)
+    members = [tarfile.TarInfo("crate")]
+
+    extract_tar_members(archive, members, "/destination")
+
+    archive.extractall.assert_called_once_with(
+        "/destination",
+        members=members,
+        filter="data",
+    )
 
 
 def test_absolute_path_returns_os_absolute_path(

--- a/tests/unit/test_rust_crates_io_collection_strategy.py
+++ b/tests/unit/test_rust_crates_io_collection_strategy.py
@@ -16,9 +16,6 @@ from pytest import LogCaptureFixture
 from dd_license_attribution.artifact_management.artifact_manager import (
     SourceCodeReference,
 )
-from dd_license_attribution.artifact_management.rust_package_resolver import (
-    CRATES_IO_USER_AGENT,
-)
 from dd_license_attribution.metadata_collector.metadata import Metadata
 from dd_license_attribution.metadata_collector.strategies.rust_collection_strategy import (
     mark_rust_metadata,
@@ -27,6 +24,7 @@ from dd_license_attribution.metadata_collector.strategies.rust_crates_io_collect
     CRATES_IO_API_BASE_URL,
     RustCratesIoMetadataCollectionStrategy,
 )
+from dd_license_attribution.utils.bounded_download import DDLA_USER_AGENT
 
 
 def _metadata(
@@ -195,7 +193,7 @@ helper = { path = "." }
 
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
         side_effect=download,
     )
     mock_read_archive = mocker.patch(
@@ -286,23 +284,23 @@ helper = { path = "." }
         [
             call(
                 f"{CRATES_IO_API_BASE_URL}/regex",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
             call(
                 f"{CRATES_IO_API_BASE_URL}/regex/1.13.0/download",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
             call(
                 f"{CRATES_IO_API_BASE_URL}/tracing-subscriber",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
             call(
                 f"{CRATES_IO_API_BASE_URL}/tracing-subscriber/0.3.20/download",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
             call(
                 f"{CRATES_IO_API_BASE_URL}/explicit-crates-io",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
         ]
     )
@@ -339,7 +337,7 @@ def test_complete_metadata_still_receives_locked_version_and_repository_origin(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
         return_value=_crate_response(
             "serde",
             "1.0.0",
@@ -380,7 +378,7 @@ def test_complete_metadata_still_receives_locked_version_and_repository_origin(
     mock_open_file.assert_called_once_with("/project/Cargo.lock")
     mock_download.assert_called_once_with(
         f"{CRATES_IO_API_BASE_URL}/serde",
-        user_agent=CRATES_IO_USER_AGENT,
+        user_agent=DDLA_USER_AGENT,
     )
 
 
@@ -405,7 +403,7 @@ def test_direct_root_package_is_enriched_from_manifest_version(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
         side_effect=[
             _crate_response(
                 "serde",
@@ -447,11 +445,11 @@ def test_direct_root_package_is_enriched_from_manifest_version(
         [
             call(
                 f"{CRATES_IO_API_BASE_URL}/serde",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
             call(
                 f"{CRATES_IO_API_BASE_URL}/serde/1.0.0/download",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
         ]
     )
@@ -489,7 +487,7 @@ def test_repository_mode_ignores_manifest_ranges_without_lockfile(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url"
+        "rust_crates_io_collection_strategy.download_bounded"
     )
     mock_read_archive = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
@@ -557,7 +555,7 @@ def test_repository_mode_does_not_enrich_unmarked_same_name_metadata(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url"
+        "rust_crates_io_collection_strategy.download_bounded"
     )
     strategy = RustCratesIoMetadataCollectionStrategy(
         "https://github.com/org/project",
@@ -618,7 +616,7 @@ def test_repository_mode_enriches_marked_rust_metadata(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
         side_effect=[
             _crate_response(
                 "serde",
@@ -665,11 +663,11 @@ def test_repository_mode_enriches_marked_rust_metadata(
         [
             call(
                 f"{CRATES_IO_API_BASE_URL}/serde",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
             call(
                 f"{CRATES_IO_API_BASE_URL}/serde/1.0.228/download",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
         ]
     )
@@ -719,7 +717,7 @@ def test_locked_crate_is_used_when_manifest_is_missing(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
         return_value=json.dumps(
             {
                 "crate": {"default_version": "1.0.0", "repository": 1},
@@ -758,7 +756,7 @@ def test_locked_crate_is_used_when_manifest_is_missing(
     mock_open_file.assert_called_once_with("/project/Cargo.lock")
     mock_download.assert_called_once_with(
         f"{CRATES_IO_API_BASE_URL}/regex",
-        user_agent=CRATES_IO_USER_AGENT,
+        user_agent=DDLA_USER_AGENT,
     )
     mock_read_archive.assert_not_called()
 
@@ -789,7 +787,7 @@ def test_locked_crate_version_takes_precedence_over_manifest_exact_pin(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
         return_value=_crate_response(
             "regex",
             "1.13.0",
@@ -829,7 +827,7 @@ def test_locked_crate_version_takes_precedence_over_manifest_exact_pin(
     assert mock_open_file.call_count == 2
     mock_download.assert_called_once_with(
         f"{CRATES_IO_API_BASE_URL}/regex",
-        user_agent=CRATES_IO_USER_AGENT,
+        user_agent=DDLA_USER_AGENT,
     )
     mock_read_archive.assert_not_called()
 
@@ -858,7 +856,7 @@ def test_crates_io_cache_distinguishes_author_fetches(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
         side_effect=[
             _crate_response(
                 "regex",
@@ -921,15 +919,15 @@ def test_crates_io_cache_distinguishes_author_fetches(
         [
             call(
                 f"{CRATES_IO_API_BASE_URL}/regex",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
             call(
                 f"{CRATES_IO_API_BASE_URL}/regex",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
             call(
                 f"{CRATES_IO_API_BASE_URL}/regex/1.13.0/download",
-                user_agent=CRATES_IO_USER_AGENT,
+                user_agent=DDLA_USER_AGENT,
             ),
         ]
     )
@@ -963,7 +961,7 @@ def test_unparseable_manifest_version_is_ignored(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
         side_effect=[
             _crate_response(
                 "regex",
@@ -1023,7 +1021,7 @@ def test_ambiguous_locked_versions_do_not_set_version_or_enrich(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url"
+        "rust_crates_io_collection_strategy.download_bounded"
     )
     strategy = RustCratesIoMetadataCollectionStrategy(
         "project",
@@ -1068,7 +1066,7 @@ def test_manifest_requirement_without_exact_version_is_not_enriched(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url"
+        "rust_crates_io_collection_strategy.download_bounded"
     )
     strategy = RustCratesIoMetadataCollectionStrategy(
         "project",
@@ -1129,7 +1127,7 @@ def test_invalid_crates_io_metadata_is_ignored(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
     )
     if isinstance(metadata_response, OSError):
         mock_download.side_effect = metadata_response
@@ -1159,7 +1157,7 @@ def test_invalid_crates_io_metadata_is_ignored(
     mock_open_file.assert_called_once_with("/project/Cargo.toml")
     mock_download.assert_called_once_with(
         f"{CRATES_IO_API_BASE_URL}/regex",
-        user_agent=CRATES_IO_USER_AGENT,
+        user_agent=DDLA_USER_AGENT,
     )
     mock_read_archive.assert_not_called()
 
@@ -1199,7 +1197,7 @@ def test_author_metadata_failures_preserve_other_crate_metadata(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url",
+        "rust_crates_io_collection_strategy.download_bounded",
         side_effect=[
             _crate_response(
                 "regex",
@@ -1288,7 +1286,7 @@ def test_invalid_cargo_file_is_ignored(
     )
     mock_download = mocker.patch(
         "dd_license_attribution.metadata_collector.strategies."
-        "rust_crates_io_collection_strategy.download_url"
+        "rust_crates_io_collection_strategy.download_bounded"
     )
     strategy = RustCratesIoMetadataCollectionStrategy(
         "project",

--- a/tests/unit/test_rust_package_resolver.py
+++ b/tests/unit/test_rust_package_resolver.py
@@ -5,9 +5,12 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2026-present Datadog, Inc.
 
+import io
 import json
 import logging
+import tarfile
 import tomllib
+from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, call
 
@@ -18,7 +21,6 @@ from dd_license_attribution.artifact_management.artifact_manager import (
     SourceCodeReference,
 )
 from dd_license_attribution.artifact_management.rust_package_resolver import (
-    CRATES_IO_USER_AGENT,
     RUST_CARGO_COMMAND_TIMEOUT_SECONDS,
     SYNTHETIC_PACKAGE_NAME,
     RustPackageResolver,
@@ -26,6 +28,17 @@ from dd_license_attribution.artifact_management.rust_package_resolver import (
 from dd_license_attribution.artifact_management.source_code_manager import (
     NonAccessibleRepository,
 )
+from dd_license_attribution.utils.bounded_download import DDLA_USER_AGENT
+
+
+def _tar_gz_with_files(files: dict[str, bytes]) -> bytes:
+    archive_bytes = io.BytesIO()
+    with tarfile.open(fileobj=archive_bytes, mode="w:gz") as archive:
+        for name, content in files.items():
+            member = tarfile.TarInfo(name)
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+    return archive_bytes.getvalue()
 
 
 class TestParseRustSpec:
@@ -165,8 +178,8 @@ class TestResolvePackage:
             "dd_license_attribution.artifact_management.rust_package_resolver.open_file",
             return_value=cargo_lock_content,
         )
-        mock_download_url = mocker.patch(
-            "dd_license_attribution.artifact_management.rust_package_resolver.download_url",
+        mock_download_bounded = mocker.patch(
+            "dd_license_attribution.artifact_management.rust_package_resolver.download_bounded",
             return_value=b"crate archive",
         )
         mock_extract_tar_gz = mocker.patch(
@@ -188,7 +201,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         )
 
@@ -213,7 +226,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(mocker)
 
@@ -264,9 +277,9 @@ class TestResolvePackage:
         )
         assert mock_path_exists.call_count == 2
         mock_open_file.assert_called_once_with("/cache/serde/Cargo.lock")
-        mock_download_url.assert_called_once_with(
+        mock_download_bounded.assert_called_once_with(
             "https://crates.io/api/v1/crates/serde/1.0.0/download",
-            user_agent=CRATES_IO_USER_AGENT,
+            user_agent=DDLA_USER_AGENT,
         )
         mock_extract_tar_gz.assert_called_once_with(
             b"crate archive",
@@ -311,7 +324,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -391,9 +404,9 @@ class TestResolvePackage:
             ]
         )
         assert mock_open_file.call_count == 2
-        mock_download_url.assert_called_once_with(
+        mock_download_bounded.assert_called_once_with(
             "https://crates.io/api/v1/crates/datadog-api-client/1.0.0/download",
-            user_agent=CRATES_IO_USER_AGENT,
+            user_agent=DDLA_USER_AGENT,
         )
         mock_extract_tar_gz.assert_called_once_with(
             b"crate archive",
@@ -411,7 +424,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -430,7 +443,7 @@ class TestResolvePackage:
         assert mock_run_command.call_count == 2
         assert mock_path_exists.call_count == 2
         mock_open_file.assert_called_once_with("/cache/serde/Cargo.lock")
-        mock_download_url.assert_called_once()
+        mock_download_bounded.assert_called_once()
         mock_extract_tar_gz.assert_called_once()
 
     def test_inaccessible_crate_repository_skips_license_tool_config(
@@ -457,7 +470,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -477,7 +490,7 @@ class TestResolvePackage:
         assert mock_run_command.call_count == 2
         assert mock_path_exists.call_count == 2
         mock_open_file.assert_called_once_with("/cache/serde/Cargo.lock")
-        mock_download_url.assert_called_once()
+        mock_download_bounded.assert_called_once()
         mock_extract_tar_gz.assert_called_once()
 
     def test_repository_without_license_tool_config_is_ignored(
@@ -507,7 +520,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -533,7 +546,7 @@ class TestResolvePackage:
         )
         assert mock_path_exists.call_count == 3
         mock_open_file.assert_called_once_with("/cache/serde/Cargo.lock")
-        mock_download_url.assert_called_once()
+        mock_download_bounded.assert_called_once()
         mock_extract_tar_gz.assert_called_once()
 
     def test_license_tool_config_read_failure_does_not_fail_resolution(
@@ -563,7 +576,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -595,7 +608,7 @@ class TestResolvePackage:
             ]
         )
         assert mock_open_file.call_count == 2
-        mock_download_url.assert_called_once()
+        mock_download_bounded.assert_called_once()
         mock_extract_tar_gz.assert_called_once()
 
     def test_unavailable_repository_checkout_skips_license_tool_config(self) -> None:
@@ -640,7 +653,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -675,7 +688,7 @@ class TestResolvePackage:
         assert mock_run_command.call_count == 2
         assert mock_path_exists.call_count == 2
         mock_open_file.assert_called_once_with("/cache/anyhow/Cargo.lock")
-        mock_download_url.assert_called_once()
+        mock_download_bounded.assert_called_once()
         mock_extract_tar_gz.assert_called_once()
 
     def test_package_name_sanitizes_dir_name(
@@ -687,7 +700,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -726,7 +739,7 @@ class TestResolvePackage:
         assert mock_run_command.call_count == 2
         assert mock_path_exists.call_count == 2
         mock_open_file.assert_called_once_with("/cache/serde-json/Cargo.lock")
-        mock_download_url.assert_called_once()
+        mock_download_bounded.assert_called_once()
         mock_extract_tar_gz.assert_called_once()
 
     def test_cargo_failure_returns_none(
@@ -738,7 +751,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -760,7 +773,7 @@ class TestResolvePackage:
         )
         mock_path_exists.assert_not_called()
         mock_open_file.assert_not_called()
-        mock_download_url.assert_not_called()
+        mock_download_bounded.assert_not_called()
         mock_extract_tar_gz.assert_not_called()
 
     def test_cargo_exception_returns_none(
@@ -772,7 +785,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(mocker)
         mock_run_command.side_effect = OSError("cargo not found")
@@ -787,7 +800,7 @@ class TestResolvePackage:
         )
         mock_path_exists.assert_not_called()
         mock_open_file.assert_not_called()
-        mock_download_url.assert_not_called()
+        mock_download_bounded.assert_not_called()
         mock_extract_tar_gz.assert_not_called()
 
     def test_missing_cargo_lock_returns_none(
@@ -799,7 +812,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -816,7 +829,7 @@ class TestResolvePackage:
         )
         mock_path_exists.assert_called_once_with("/cache/serde/Cargo.lock")
         mock_open_file.assert_not_called()
-        mock_download_url.assert_not_called()
+        mock_download_bounded.assert_not_called()
         mock_extract_tar_gz.assert_not_called()
 
     def test_write_file_exception_returns_none(
@@ -828,7 +841,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(mocker)
         mock_write_file.side_effect = OSError("read-only")
@@ -841,7 +854,7 @@ class TestResolvePackage:
         mock_run_command.assert_not_called()
         mock_path_exists.assert_not_called()
         mock_open_file.assert_not_called()
-        mock_download_url.assert_not_called()
+        mock_download_bounded.assert_not_called()
         mock_extract_tar_gz.assert_not_called()
 
     def test_binary_only_crate_falls_back_to_published_source(
@@ -853,7 +866,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -906,13 +919,56 @@ class TestResolvePackage:
         )
         assert mock_path_exists.call_count == 2
         mock_open_file.assert_called_once_with("/cache/dd-rust-license-tool/Cargo.lock")
-        mock_download_url.assert_called_once_with(
+        mock_download_bounded.assert_called_once_with(
             "https://crates.io/api/v1/crates/dd-rust-license-tool/1.0.6/download",
-            user_agent=CRATES_IO_USER_AGENT,
+            user_agent=DDLA_USER_AGENT,
         )
         mock_extract_tar_gz.assert_called_once_with(
             b"crate archive",
             "/cache/dd-rust-license-tool/crate-source",
+        )
+
+    def test_crate_source_resolution_extracts_downloaded_archive(
+        self,
+        mocker: pytest_mock.MockFixture,
+        tmp_path: Path,
+    ) -> None:
+        resolver = RustPackageResolver(str(tmp_path))
+        archive_content = _tar_gz_with_files(
+            {
+                "binary-only-1.0.0/Cargo.toml": (
+                    b'[package]\nname = "binary-only"\nversion = "1.0.0"\n'
+                ),
+                "binary-only-1.0.0/src/main.rs": b"fn main() {}\n",
+            }
+        )
+        mock_download_bounded = mocker.patch(
+            "dd_license_attribution.artifact_management.rust_package_resolver.download_bounded",
+            return_value=archive_content,
+        )
+
+        result = resolver._resolve_crate_from_source(
+            "binary-only",
+            "binary-only@1.0.0",
+            str(tmp_path / "binary-only"),
+            str(tmp_path / "binary-only" / "Cargo.lock"),
+            repository=None,
+            resolved_version="1.0.0",
+        )
+
+        assert result == str(
+            tmp_path / "binary-only" / "crate-source" / "binary-only-1.0.0"
+        )
+        assert (
+            tmp_path
+            / "binary-only"
+            / "crate-source"
+            / "binary-only-1.0.0"
+            / "Cargo.toml"
+        ).read_text() == '[package]\nname = "binary-only"\nversion = "1.0.0"\n'
+        mock_download_bounded.assert_called_once_with(
+            "https://crates.io/api/v1/crates/binary-only/1.0.0/download",
+            user_agent=DDLA_USER_AGENT,
         )
 
     def test_binary_only_crate_copies_repository_license_tool_config(
@@ -941,7 +997,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -951,7 +1007,7 @@ class TestResolvePackage:
             extracted_members=["dd-rust-license-tool-1.0.6/Cargo.toml"],
         )
         mock_open_file.side_effect = [cargo_lock_content, config_content]
-        mock_download_url.side_effect = [
+        mock_download_bounded.side_effect = [
             json.dumps(
                 {
                     "version": {
@@ -1016,19 +1072,19 @@ class TestResolvePackage:
             ]
         )
         assert mock_open_file.call_count == 2
-        mock_download_url.assert_has_calls(
+        mock_download_bounded.assert_has_calls(
             [
                 call(
                     "https://crates.io/api/v1/crates/dd-rust-license-tool/1.0.6",
-                    user_agent=CRATES_IO_USER_AGENT,
+                    user_agent=DDLA_USER_AGENT,
                 ),
                 call(
                     "https://crates.io/api/v1/crates/dd-rust-license-tool/1.0.6/download",
-                    user_agent=CRATES_IO_USER_AGENT,
+                    user_agent=DDLA_USER_AGENT,
                 ),
             ]
         )
-        assert mock_download_url.call_count == 2
+        assert mock_download_bounded.call_count == 2
         mock_extract_tar_gz.assert_called_once_with(
             b"crate archive",
             "/cache/dd-rust-license-tool/crate-source",
@@ -1037,8 +1093,8 @@ class TestResolvePackage:
     def test_crates_io_repository_metadata_failure_returns_none(
         self, mocker: pytest_mock.MockFixture, caplog: LogCaptureFixture
     ) -> None:
-        mock_download_url = mocker.patch(
-            "dd_license_attribution.artifact_management.rust_package_resolver.download_url",
+        mock_download_bounded = mocker.patch(
+            "dd_license_attribution.artifact_management.rust_package_resolver.download_bounded",
             side_effect=OSError("network unavailable"),
         )
 
@@ -1047,16 +1103,16 @@ class TestResolvePackage:
 
         assert result is None
         assert "Could not retrieve crates.io metadata" in caplog.text
-        mock_download_url.assert_called_once_with(
+        mock_download_bounded.assert_called_once_with(
             "https://crates.io/api/v1/crates/serde/1.0.0",
-            user_agent=CRATES_IO_USER_AGENT,
+            user_agent=DDLA_USER_AGENT,
         )
 
     def test_crates_io_repository_falls_back_to_crate_metadata(
         self, mocker: pytest_mock.MockFixture
     ) -> None:
-        mock_download_url = mocker.patch(
-            "dd_license_attribution.artifact_management.rust_package_resolver.download_url",
+        mock_download_bounded = mocker.patch(
+            "dd_license_attribution.artifact_management.rust_package_resolver.download_bounded",
             return_value=json.dumps(
                 {
                     "crate": {"repository": "https://github.com/serde-rs/serde"},
@@ -1068,9 +1124,9 @@ class TestResolvePackage:
         result = self.resolver._get_crates_io_repository("serde", "1.0.0")
 
         assert result == "https://github.com/serde-rs/serde"
-        mock_download_url.assert_called_once_with(
+        mock_download_bounded.assert_called_once_with(
             "https://crates.io/api/v1/crates/serde/1.0.0",
-            user_agent=CRATES_IO_USER_AGENT,
+            user_agent=DDLA_USER_AGENT,
         )
 
     def test_get_resolved_crate_version_reads_cargo_lock(
@@ -1168,7 +1224,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -1199,7 +1255,7 @@ class TestResolvePackage:
         assert mock_run_command.call_count == 2
         mock_path_exists.assert_called_once_with("/cache/serde/Cargo.lock")
         mock_open_file.assert_not_called()
-        mock_download_url.assert_not_called()
+        mock_download_bounded.assert_not_called()
         mock_extract_tar_gz.assert_not_called()
 
     def test_metadata_exception_returns_none(
@@ -1211,7 +1267,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(mocker)
         mock_run_command.side_effect = [
@@ -1244,7 +1300,7 @@ class TestResolvePackage:
         assert mock_run_command.call_count == 2
         mock_path_exists.assert_called_once_with("/cache/serde/Cargo.lock")
         mock_open_file.assert_not_called()
-        mock_download_url.assert_not_called()
+        mock_download_bounded.assert_not_called()
         mock_extract_tar_gz.assert_not_called()
 
     def test_invalid_metadata_json_returns_none(
@@ -1256,7 +1312,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -1288,7 +1344,7 @@ class TestResolvePackage:
         assert mock_run_command.call_count == 2
         mock_path_exists.assert_called_once_with("/cache/serde/Cargo.lock")
         mock_open_file.assert_not_called()
-        mock_download_url.assert_not_called()
+        mock_download_bounded.assert_not_called()
         mock_extract_tar_gz.assert_not_called()
 
     def test_metadata_non_object_returns_none(self, caplog: LogCaptureFixture) -> None:
@@ -1324,7 +1380,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -1360,7 +1416,7 @@ class TestResolvePackage:
         assert mock_run_command.call_count == 2
         mock_path_exists.assert_called_once_with("/cache/serde/Cargo.lock")
         mock_open_file.assert_not_called()
-        mock_download_url.assert_not_called()
+        mock_download_bounded.assert_not_called()
         mock_extract_tar_gz.assert_not_called()
 
     def test_missing_lib_target_warning_detection_requires_all_terms(self) -> None:
@@ -1414,7 +1470,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -1449,7 +1505,7 @@ class TestResolvePackage:
             "/cache/dd-rust-license-tool/Cargo.lock"
         )
         mock_open_file.assert_called_once_with("/cache/dd-rust-license-tool/Cargo.lock")
-        mock_download_url.assert_not_called()
+        mock_download_bounded.assert_not_called()
         mock_extract_tar_gz.assert_not_called()
 
     def test_lockfile_read_failure_returns_none(
@@ -1570,7 +1626,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -1580,7 +1636,7 @@ class TestResolvePackage:
                 "1.0.6",
             ),
         )
-        mock_download_url.side_effect = OSError("network unavailable")
+        mock_download_bounded.side_effect = OSError("network unavailable")
 
         with caplog.at_level(logging.ERROR):
             result = self.resolver.resolve_package("dd-rust-license-tool")
@@ -1609,9 +1665,9 @@ class TestResolvePackage:
             "/cache/dd-rust-license-tool/Cargo.lock"
         )
         mock_open_file.assert_called_once_with("/cache/dd-rust-license-tool/Cargo.lock")
-        mock_download_url.assert_called_once_with(
+        mock_download_bounded.assert_called_once_with(
             "https://crates.io/api/v1/crates/dd-rust-license-tool/1.0.6/download",
-            user_agent=CRATES_IO_USER_AGENT,
+            user_agent=DDLA_USER_AGENT,
         )
         mock_extract_tar_gz.assert_not_called()
 
@@ -1624,7 +1680,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -1660,9 +1716,9 @@ class TestResolvePackage:
             "/cache/dd-rust-license-tool/Cargo.lock"
         )
         mock_open_file.assert_called_once_with("/cache/dd-rust-license-tool/Cargo.lock")
-        mock_download_url.assert_called_once_with(
+        mock_download_bounded.assert_called_once_with(
             "https://crates.io/api/v1/crates/dd-rust-license-tool/1.0.6/download",
-            user_agent=CRATES_IO_USER_AGENT,
+            user_agent=DDLA_USER_AGENT,
         )
         mock_extract_tar_gz.assert_called_once_with(
             b"crate archive",
@@ -1678,7 +1734,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -1717,9 +1773,9 @@ class TestResolvePackage:
             "/cache/dd-rust-license-tool/Cargo.lock"
         )
         mock_open_file.assert_called_once_with("/cache/dd-rust-license-tool/Cargo.lock")
-        mock_download_url.assert_called_once_with(
+        mock_download_bounded.assert_called_once_with(
             "https://crates.io/api/v1/crates/dd-rust-license-tool/1.0.6/download",
-            user_agent=CRATES_IO_USER_AGENT,
+            user_agent=DDLA_USER_AGENT,
         )
         mock_extract_tar_gz.assert_called_once_with(
             b"crate archive",
@@ -1775,7 +1831,7 @@ class TestResolvePackage:
             mock_run_command,
             mock_path_exists,
             mock_open_file,
-            mock_download_url,
+            mock_download_bounded,
             mock_extract_tar_gz,
         ) = self._setup_mocks(
             mocker,
@@ -1821,9 +1877,9 @@ class TestResolvePackage:
         )
         assert mock_path_exists.call_count == 2
         mock_open_file.assert_called_once_with("/cache/dd-rust-license-tool/Cargo.lock")
-        mock_download_url.assert_called_once_with(
+        mock_download_bounded.assert_called_once_with(
             "https://crates.io/api/v1/crates/dd-rust-license-tool/1.0.6/download",
-            user_agent=CRATES_IO_USER_AGENT,
+            user_agent=DDLA_USER_AGENT,
         )
         mock_extract_tar_gz.assert_called_once_with(
             b"crate archive",

--- a/tests/unit/test_tar_archive.py
+++ b/tests/unit/test_tar_archive.py
@@ -69,6 +69,34 @@ def _tar_gz_with_read_only_directory() -> bytes:
     return archive_bytes.getvalue()
 
 
+def _mock_extract_tar_members(
+    mocker: pytest_mock.MockFixture,
+) -> tuple[Mock, list[tarfile.TarFile], list[str], list[str]]:
+    captured_archives: list[tarfile.TarFile] = []
+    captured_member_names: list[str] = []
+    captured_destinations: list[str] = []
+
+    def fake_extract_tar_members(
+        archive: tarfile.TarFile,
+        members: Iterator[tarfile.TarInfo],
+        destination: str,
+    ) -> None:
+        captured_archives.append(archive)
+        captured_destinations.append(destination)
+        captured_member_names.extend(member.name for member in members)
+
+    mock_extract_tar_members = mocker.patch(
+        "dd_license_attribution.utils.tar_archive.extract_tar_members",
+        side_effect=fake_extract_tar_members,
+    )
+    return (
+        mock_extract_tar_members,
+        captured_archives,
+        captured_member_names,
+        captured_destinations,
+    )
+
+
 @pytest.mark.parametrize(
     "member_type",
     [
@@ -188,13 +216,22 @@ def test_extract_tar_gz_rejects_total_extracted_size_over_limit(
         )
 
 
-def test_extract_tar_gz_accepts_exact_extracted_size_limit(tmp_path: Path) -> None:
+def test_extract_tar_gz_accepts_exact_extracted_size_limit(
+    tmp_path: Path,
+    mocker: pytest_mock.MockFixture,
+) -> None:
     archive_content = _tar_gz_with_files(
         {
             "crate/one.txt": b"x" * 10,
             "crate/two.txt": b"y" * 10,
         }
     )
+    (
+        mock_extract_tar_members,
+        _captured_archives,
+        captured_member_names,
+        captured_destinations,
+    ) = _mock_extract_tar_members(mocker)
 
     result = extract_tar_gz(
         archive_content,
@@ -203,14 +240,22 @@ def test_extract_tar_gz_accepts_exact_extracted_size_limit(tmp_path: Path) -> No
     )
 
     assert result == ["crate/one.txt", "crate/two.txt"]
-    assert (tmp_path / "crate" / "one.txt").read_bytes() == b"x" * 10
-    assert (tmp_path / "crate" / "two.txt").read_bytes() == b"y" * 10
+    mock_extract_tar_members.assert_called_once()
+    assert captured_member_names == ["crate/one.txt", "crate/two.txt"]
+    assert captured_destinations == [str(tmp_path)]
 
 
 def test_extract_tar_gz_accepts_single_byte_extracted_size_limit(
     tmp_path: Path,
+    mocker: pytest_mock.MockFixture,
 ) -> None:
     archive_content = _tar_gz_with_files({"crate/one.txt": b"x"})
+    (
+        mock_extract_tar_members,
+        _captured_archives,
+        captured_member_names,
+        captured_destinations,
+    ) = _mock_extract_tar_members(mocker)
 
     result = extract_tar_gz(
         archive_content,
@@ -219,7 +264,9 @@ def test_extract_tar_gz_accepts_single_byte_extracted_size_limit(
     )
 
     assert result == ["crate/one.txt"]
-    assert (tmp_path / "crate" / "one.txt").read_bytes() == b"x"
+    mock_extract_tar_members.assert_called_once()
+    assert captured_member_names == ["crate/one.txt"]
+    assert captured_destinations == [str(tmp_path)]
 
 
 def test_extract_tar_gz_rejects_malformed_archive(tmp_path: Path) -> None:
@@ -234,19 +281,31 @@ def test_extract_tar_gz_rejects_truncated_gzip(tmp_path: Path) -> None:
         extract_tar_gz(archive_content[: len(archive_content) // 2], str(tmp_path))
 
 
-def test_extract_tar_gz_allows_tar_trailing_garbage_after_eof(tmp_path: Path) -> None:
+def test_extract_tar_gz_allows_tar_trailing_garbage_after_eof(
+    tmp_path: Path,
+    mocker: pytest_mock.MockFixture,
+) -> None:
     archive_content = _tar_gz_with_file_and_trailing_garbage(
         {"crate/Cargo.toml": b"[package]\n"}
     )
+    (
+        mock_extract_tar_members,
+        _captured_archives,
+        captured_member_names,
+        captured_destinations,
+    ) = _mock_extract_tar_members(mocker)
 
     result = extract_tar_gz(archive_content, str(tmp_path))
 
     assert result == ["crate/Cargo.toml"]
-    assert (tmp_path / "crate" / "Cargo.toml").read_text() == "[package]\n"
+    mock_extract_tar_members.assert_called_once()
+    assert captured_member_names == ["crate/Cargo.toml"]
+    assert captured_destinations == [str(tmp_path)]
 
 
 def test_extract_tar_gz_writes_nothing_when_later_member_is_rejected(
     tmp_path: Path,
+    mocker: pytest_mock.MockFixture,
 ) -> None:
     archive_content = _tar_gz_with_files(
         {
@@ -254,15 +313,19 @@ def test_extract_tar_gz_writes_nothing_when_later_member_is_rejected(
             "../escape.txt": b"escape",
         }
     )
+    mock_extract_tar_members = mocker.patch(
+        "dd_license_attribution.utils.tar_archive.extract_tar_members"
+    )
 
     with pytest.raises(ValueError, match="Unsafe archive path"):
         extract_tar_gz(archive_content, str(tmp_path))
 
-    assert list(tmp_path.iterdir()) == []
+    mock_extract_tar_members.assert_not_called()
 
 
-def test_extract_tar_gz_returns_members_in_archive_order_and_extracts_root(
+def test_extract_tar_gz_returns_members_in_archive_order_and_calls_adaptor(
     tmp_path: Path,
+    mocker: pytest_mock.MockFixture,
 ) -> None:
     archive_content = _tar_gz_with_files(
         {
@@ -270,14 +333,22 @@ def test_extract_tar_gz_returns_members_in_archive_order_and_extracts_root(
             "demo-1.2.3/src/lib.rs": b"pub fn demo() {}\n",
         }
     )
+    (
+        mock_extract_tar_members,
+        _captured_archives,
+        captured_member_names,
+        captured_destinations,
+    ) = _mock_extract_tar_members(mocker)
 
     result = extract_tar_gz(archive_content, str(tmp_path))
 
     assert result == ["demo-1.2.3/Cargo.toml", "demo-1.2.3/src/lib.rs"]
-    assert (tmp_path / "demo-1.2.3" / "Cargo.toml").read_bytes() == b"[package]\n"
-    assert (
-        tmp_path / "demo-1.2.3" / "src" / "lib.rs"
-    ).read_bytes() == b"pub fn demo() {}\n"
+    mock_extract_tar_members.assert_called_once()
+    assert captured_member_names == [
+        "demo-1.2.3/Cargo.toml",
+        "demo-1.2.3/src/lib.rs",
+    ]
+    assert captured_destinations == [str(tmp_path)]
 
 
 def test_extract_tar_gz_uses_os_adaptor_for_extraction(
@@ -285,48 +356,41 @@ def test_extract_tar_gz_uses_os_adaptor_for_extraction(
     mocker: pytest_mock.MockFixture,
 ) -> None:
     archive_content = _tar_gz_with_files({"crate/Cargo.toml": b"[package]\n"})
-    captured_member_names: list[str] = []
-    captured_destination = ""
-    captured_archive: tarfile.TarFile | None = None
-
-    def fake_extract_tar_members(
-        archive: tarfile.TarFile,
-        members: Iterator[tarfile.TarInfo],
-        destination: str,
-    ) -> None:
-        nonlocal captured_archive, captured_destination
-        captured_archive = archive
-        captured_destination = destination
-        captured_member_names.extend(member.name for member in members)
-
-    mock_extract_tar_members = mocker.patch(
-        "dd_license_attribution.utils.tar_archive.extract_tar_members",
-        side_effect=fake_extract_tar_members,
-    )
+    (
+        mock_extract_tar_members,
+        captured_archives,
+        captured_member_names,
+        captured_destinations,
+    ) = _mock_extract_tar_members(mocker)
 
     result = extract_tar_gz(archive_content, str(tmp_path))
 
     assert result == ["crate/Cargo.toml"]
     mock_extract_tar_members.assert_called_once()
-    assert isinstance(captured_archive, tarfile.TarFile)
+    assert len(captured_archives) == 1
+    assert isinstance(captured_archives[0], tarfile.TarFile)
     assert captured_member_names == ["crate/Cargo.toml"]
-    assert captured_destination == str(tmp_path)
+    assert captured_destinations == [str(tmp_path)]
 
 
-def test_extract_tar_gz_defers_directory_permissions_until_children_are_extracted(
+def test_extract_tar_gz_passes_directory_members_to_os_adaptor(
     tmp_path: Path,
+    mocker: pytest_mock.MockFixture,
 ) -> None:
     archive_content = _tar_gz_with_read_only_directory()
-    directory_path = tmp_path / "crate"
+    (
+        mock_extract_tar_members,
+        _captured_archives,
+        captured_member_names,
+        captured_destinations,
+    ) = _mock_extract_tar_members(mocker)
 
-    try:
-        result = extract_tar_gz(archive_content, str(tmp_path))
+    result = extract_tar_gz(archive_content, str(tmp_path))
 
-        assert result == ["crate", "crate/Cargo.toml"]
-        assert (directory_path / "Cargo.toml").read_bytes() == b"[package]\n"
-    finally:
-        if directory_path.exists():
-            directory_path.chmod(0o700)
+    assert result == ["crate", "crate/Cargo.toml"]
+    mock_extract_tar_members.assert_called_once()
+    assert captured_member_names == ["crate", "crate/Cargo.toml"]
+    assert captured_destinations == [str(tmp_path)]
 
 
 def test_read_tar_gz_text_file_reads_matching_member() -> None:

--- a/tests/unit/test_tar_archive.py
+++ b/tests/unit/test_tar_archive.py
@@ -10,6 +10,7 @@ import io
 import tarfile
 from collections.abc import Iterator
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 import pytest_mock
@@ -136,16 +137,15 @@ def test_extract_tar_gz_rejects_too_many_members(tmp_path: Path) -> None:
 
 
 def test_extract_tar_gz_rejects_invalid_member_limit(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="max_members must be greater than zero"):
+    with pytest.raises(ValueError) as exc_info:
         extract_tar_gz(b"archive", str(tmp_path), max_members=0)
+    assert str(exc_info.value) == "max_members must be greater than zero"
 
 
 def test_extract_tar_gz_rejects_invalid_extracted_size_limit(tmp_path: Path) -> None:
-    with pytest.raises(
-        ValueError,
-        match="max_extracted_bytes must be greater than zero",
-    ):
+    with pytest.raises(ValueError) as exc_info:
         extract_tar_gz(b"archive", str(tmp_path), max_extracted_bytes=0)
+    assert str(exc_info.value) == "max_extracted_bytes must be greater than zero"
 
 
 def test_extract_tar_gz_rejects_file_over_extracted_size_limit(
@@ -205,6 +205,21 @@ def test_extract_tar_gz_accepts_exact_extracted_size_limit(tmp_path: Path) -> No
     assert result == ["crate/one.txt", "crate/two.txt"]
     assert (tmp_path / "crate" / "one.txt").read_bytes() == b"x" * 10
     assert (tmp_path / "crate" / "two.txt").read_bytes() == b"y" * 10
+
+
+def test_extract_tar_gz_accepts_single_byte_extracted_size_limit(
+    tmp_path: Path,
+) -> None:
+    archive_content = _tar_gz_with_files({"crate/one.txt": b"x"})
+
+    result = extract_tar_gz(
+        archive_content,
+        str(tmp_path),
+        max_extracted_bytes=1,
+    )
+
+    assert result == ["crate/one.txt"]
+    assert (tmp_path / "crate" / "one.txt").read_bytes() == b"x"
 
 
 def test_extract_tar_gz_rejects_malformed_archive(tmp_path: Path) -> None:
@@ -358,14 +373,28 @@ def test_read_tar_gz_text_file_accepts_exact_size_limit() -> None:
     assert result == "x" * 20
 
 
+def test_read_tar_gz_text_file_accepts_single_byte_size_limit() -> None:
+    archive_content = _tar_gz_with_files({"crate/Cargo.toml": b"x"})
+
+    result = read_tar_gz_text_file(
+        archive_content,
+        "/Cargo.toml",
+        max_bytes=1,
+    )
+
+    assert result == "x"
+
+
 def test_read_tar_gz_text_file_rejects_invalid_size_limit() -> None:
-    with pytest.raises(ValueError, match="max_bytes must be greater than zero"):
+    with pytest.raises(ValueError) as exc_info:
         read_tar_gz_text_file(b"archive", "/Cargo.toml", max_bytes=0)
+    assert str(exc_info.value) == "max_bytes must be greater than zero"
 
 
 def test_read_tar_gz_text_file_rejects_invalid_member_limit() -> None:
-    with pytest.raises(ValueError, match="max_members must be greater than zero"):
+    with pytest.raises(ValueError) as exc_info:
         read_tar_gz_text_file(b"archive", "/Cargo.toml", max_members=0)
+    assert str(exc_info.value) == "max_members must be greater than zero"
 
 
 def test_read_tar_gz_text_file_rejects_too_many_members_before_match() -> None:
@@ -433,6 +462,22 @@ def test_bounded_reader_caps_large_requested_read_before_delegating() -> None:
         assert gzip_stream.tell() == 21
 
 
+def test_bounded_reader_caps_large_read_after_partial_consumption() -> None:
+    compressed_content = gzip.compress(b"0123456789")
+
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed_content)) as gzip_stream:
+        reader = _BoundedGzipReader(gzip_stream, max_bytes=5, max_content_bytes=5)
+
+        assert reader.read(3) == b"012"
+        with pytest.raises(
+            ValueError,
+            match="Archive exceeds maximum extracted size of 5 bytes",
+        ):
+            reader.read(10)
+
+        assert gzip_stream.tell() == 6
+
+
 def test_bounded_reader_rejects_when_already_over_budget() -> None:
     compressed_content = gzip.compress(b"x" * 10)
 
@@ -476,6 +521,18 @@ def test_bounded_reader_supports_small_forward_and_backward_seeks() -> None:
         assert reader.tell() == 10
         assert reader.seek(2) == 2
         assert reader.tell() == 2
+
+
+def test_bounded_reader_seek_to_current_position_does_not_touch_raw_stream() -> None:
+    raw = Mock(spec=gzip.GzipFile)
+    raw.tell.return_value = 5
+    reader = _BoundedGzipReader(raw, max_bytes=20, max_content_bytes=20)
+
+    assert reader.seek(5) == 5
+
+    raw.tell.assert_called()
+    raw.seek.assert_not_called()
+    raw.read.assert_not_called()
 
 
 def test_bounded_reader_stops_forward_seek_at_eof() -> None:

--- a/tests/unit/test_tar_archive.py
+++ b/tests/unit/test_tar_archive.py
@@ -8,9 +8,11 @@
 import gzip
 import io
 import tarfile
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+import pytest_mock
 
 from dd_license_attribution.utils.tar_archive import (
     MAX_ARCHIVE_MEMBERS,
@@ -49,6 +51,21 @@ def _tar_gz_with_file_and_trailing_garbage(files: dict[str, bytes]) -> bytes:
             archive.addfile(member, io.BytesIO(content))
     tar_with_garbage = archive_bytes.getvalue() + b"trailing garbage"
     return gzip.compress(tar_with_garbage)
+
+
+def _tar_gz_with_read_only_directory() -> bytes:
+    archive_bytes = io.BytesIO()
+    with tarfile.open(fileobj=archive_bytes, mode="w:gz") as archive:
+        directory = tarfile.TarInfo("crate")
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o500
+        archive.addfile(directory)
+
+        member = tarfile.TarInfo("crate/Cargo.toml")
+        content = b"[package]\n"
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+    return archive_bytes.getvalue()
 
 
 @pytest.mark.parametrize(
@@ -246,6 +263,55 @@ def test_extract_tar_gz_returns_members_in_archive_order_and_extracts_root(
     assert (
         tmp_path / "demo-1.2.3" / "src" / "lib.rs"
     ).read_bytes() == b"pub fn demo() {}\n"
+
+
+def test_extract_tar_gz_uses_os_adaptor_for_extraction(
+    tmp_path: Path,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    archive_content = _tar_gz_with_files({"crate/Cargo.toml": b"[package]\n"})
+    captured_member_names: list[str] = []
+    captured_destination = ""
+    captured_archive: tarfile.TarFile | None = None
+
+    def fake_extract_tar_members(
+        archive: tarfile.TarFile,
+        members: Iterator[tarfile.TarInfo],
+        destination: str,
+    ) -> None:
+        nonlocal captured_archive, captured_destination
+        captured_archive = archive
+        captured_destination = destination
+        captured_member_names.extend(member.name for member in members)
+
+    mock_extract_tar_members = mocker.patch(
+        "dd_license_attribution.utils.tar_archive.extract_tar_members",
+        side_effect=fake_extract_tar_members,
+    )
+
+    result = extract_tar_gz(archive_content, str(tmp_path))
+
+    assert result == ["crate/Cargo.toml"]
+    mock_extract_tar_members.assert_called_once()
+    assert isinstance(captured_archive, tarfile.TarFile)
+    assert captured_member_names == ["crate/Cargo.toml"]
+    assert captured_destination == str(tmp_path)
+
+
+def test_extract_tar_gz_defers_directory_permissions_until_children_are_extracted(
+    tmp_path: Path,
+) -> None:
+    archive_content = _tar_gz_with_read_only_directory()
+    directory_path = tmp_path / "crate"
+
+    try:
+        result = extract_tar_gz(archive_content, str(tmp_path))
+
+        assert result == ["crate", "crate/Cargo.toml"]
+        assert (directory_path / "Cargo.toml").read_bytes() == b"[package]\n"
+    finally:
+        if directory_path.exists():
+            directory_path.chmod(0o700)
 
 
 def test_read_tar_gz_text_file_reads_matching_member() -> None:

--- a/tests/unit/test_tar_archive.py
+++ b/tests/unit/test_tar_archive.py
@@ -1,0 +1,455 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2026-present Datadog, Inc.
+
+import gzip
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from dd_license_attribution.utils.tar_archive import (
+    MAX_ARCHIVE_MEMBERS,
+    MAX_EXTRACTED_ARCHIVE_BYTES,
+    _BoundedGzipReader,
+    _decompression_budget,
+    _is_safe_tar_member,
+    extract_tar_gz,
+    read_tar_gz_text_file,
+)
+
+
+def _tar_gz_with_member(member: tarfile.TarInfo) -> bytes:
+    archive_bytes = io.BytesIO()
+    with tarfile.open(fileobj=archive_bytes, mode="w:gz") as archive:
+        archive.addfile(member)
+    return archive_bytes.getvalue()
+
+
+def _tar_gz_with_files(files: dict[str, bytes]) -> bytes:
+    archive_bytes = io.BytesIO()
+    with tarfile.open(fileobj=archive_bytes, mode="w:gz") as archive:
+        for name, content in files.items():
+            member = tarfile.TarInfo(name)
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+    return archive_bytes.getvalue()
+
+
+def _tar_gz_with_file_and_trailing_garbage(files: dict[str, bytes]) -> bytes:
+    archive_bytes = io.BytesIO()
+    with tarfile.open(fileobj=archive_bytes, mode="w:") as archive:
+        for name, content in files.items():
+            member = tarfile.TarInfo(name)
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+    tar_with_garbage = archive_bytes.getvalue() + b"trailing garbage"
+    return gzip.compress(tar_with_garbage)
+
+
+@pytest.mark.parametrize(
+    "member_type",
+    [
+        tarfile.FIFOTYPE,
+        tarfile.CHRTYPE,
+        tarfile.BLKTYPE,
+    ],
+)
+def test_extract_tar_gz_rejects_special_members(
+    tmp_path: Path,
+    member_type: bytes,
+) -> None:
+    member = tarfile.TarInfo("crate/special")
+    member.type = member_type
+    archive_content = _tar_gz_with_member(member)
+
+    with pytest.raises(ValueError, match="Unsafe archive path: crate/special"):
+        extract_tar_gz(archive_content, str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "../escape.txt",
+        "crate/../../escape.txt",
+        "/tmp/escape.txt",
+        "crate\\..\\escape.txt",
+    ],
+)
+def test_extract_tar_gz_rejects_unsafe_member_paths(
+    tmp_path: Path,
+    member_name: str,
+) -> None:
+    member = tarfile.TarInfo(member_name)
+    member.size = 0
+    archive_content = _tar_gz_with_member(member)
+
+    with pytest.raises(ValueError, match="Unsafe archive path"):
+        extract_tar_gz(archive_content, str(tmp_path))
+
+
+@pytest.mark.parametrize("member_type", [tarfile.SYMTYPE, tarfile.LNKTYPE])
+def test_extract_tar_gz_rejects_link_members(
+    tmp_path: Path,
+    member_type: bytes,
+) -> None:
+    member = tarfile.TarInfo("crate/link")
+    member.type = member_type
+    member.linkname = "../escape.txt"
+    archive_content = _tar_gz_with_member(member)
+
+    with pytest.raises(ValueError, match="Unsafe archive path: crate/link"):
+        extract_tar_gz(archive_content, str(tmp_path))
+
+
+def test_extract_tar_gz_rejects_too_many_members(tmp_path: Path) -> None:
+    archive_content = _tar_gz_with_files(
+        {
+            "crate/one.txt": b"one",
+            "crate/two.txt": b"two",
+        }
+    )
+
+    with pytest.raises(ValueError, match="Archive contains more than 1 members"):
+        extract_tar_gz(archive_content, str(tmp_path), max_members=1)
+
+
+def test_extract_tar_gz_rejects_invalid_member_limit(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="max_members must be greater than zero"):
+        extract_tar_gz(b"archive", str(tmp_path), max_members=0)
+
+
+def test_extract_tar_gz_rejects_invalid_extracted_size_limit(tmp_path: Path) -> None:
+    with pytest.raises(
+        ValueError,
+        match="max_extracted_bytes must be greater than zero",
+    ):
+        extract_tar_gz(b"archive", str(tmp_path), max_extracted_bytes=0)
+
+
+def test_extract_tar_gz_rejects_file_over_extracted_size_limit(
+    tmp_path: Path,
+) -> None:
+    archive_content = _tar_gz_with_files({"crate/large.txt": b"x" * 21})
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Archive member crate/large.txt exceeds maximum extracted size "
+            "of 20 bytes"
+        ),
+    ):
+        extract_tar_gz(
+            archive_content,
+            str(tmp_path),
+            max_extracted_bytes=20,
+        )
+
+
+def test_extract_tar_gz_rejects_total_extracted_size_over_limit(
+    tmp_path: Path,
+) -> None:
+    archive_content = _tar_gz_with_files(
+        {
+            "crate/one.txt": b"x" * 10,
+            "crate/two.txt": b"y" * 11,
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Archive exceeds maximum extracted size of 20 bytes",
+    ):
+        extract_tar_gz(
+            archive_content,
+            str(tmp_path),
+            max_extracted_bytes=20,
+        )
+
+
+def test_extract_tar_gz_accepts_exact_extracted_size_limit(tmp_path: Path) -> None:
+    archive_content = _tar_gz_with_files(
+        {
+            "crate/one.txt": b"x" * 10,
+            "crate/two.txt": b"y" * 10,
+        }
+    )
+
+    result = extract_tar_gz(
+        archive_content,
+        str(tmp_path),
+        max_extracted_bytes=20,
+    )
+
+    assert result == ["crate/one.txt", "crate/two.txt"]
+    assert (tmp_path / "crate" / "one.txt").read_bytes() == b"x" * 10
+    assert (tmp_path / "crate" / "two.txt").read_bytes() == b"y" * 10
+
+
+def test_extract_tar_gz_rejects_malformed_archive(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Malformed gzip tar archive"):
+        extract_tar_gz(b"not a gzip tar archive", str(tmp_path))
+
+
+def test_extract_tar_gz_rejects_truncated_gzip(tmp_path: Path) -> None:
+    archive_content = _tar_gz_with_files({"crate/Cargo.toml": b"[package]\n"})
+
+    with pytest.raises(ValueError, match="Malformed gzip tar archive"):
+        extract_tar_gz(archive_content[: len(archive_content) // 2], str(tmp_path))
+
+
+def test_extract_tar_gz_allows_tar_trailing_garbage_after_eof(tmp_path: Path) -> None:
+    archive_content = _tar_gz_with_file_and_trailing_garbage(
+        {"crate/Cargo.toml": b"[package]\n"}
+    )
+
+    result = extract_tar_gz(archive_content, str(tmp_path))
+
+    assert result == ["crate/Cargo.toml"]
+    assert (tmp_path / "crate" / "Cargo.toml").read_text() == "[package]\n"
+
+
+def test_extract_tar_gz_writes_nothing_when_later_member_is_rejected(
+    tmp_path: Path,
+) -> None:
+    archive_content = _tar_gz_with_files(
+        {
+            "crate/one.txt": b"one",
+            "../escape.txt": b"escape",
+        }
+    )
+
+    with pytest.raises(ValueError, match="Unsafe archive path"):
+        extract_tar_gz(archive_content, str(tmp_path))
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_extract_tar_gz_returns_members_in_archive_order_and_extracts_root(
+    tmp_path: Path,
+) -> None:
+    archive_content = _tar_gz_with_files(
+        {
+            "demo-1.2.3/Cargo.toml": b"[package]\n",
+            "demo-1.2.3/src/lib.rs": b"pub fn demo() {}\n",
+        }
+    )
+
+    result = extract_tar_gz(archive_content, str(tmp_path))
+
+    assert result == ["demo-1.2.3/Cargo.toml", "demo-1.2.3/src/lib.rs"]
+    assert (tmp_path / "demo-1.2.3" / "Cargo.toml").read_bytes() == b"[package]\n"
+    assert (
+        tmp_path / "demo-1.2.3" / "src" / "lib.rs"
+    ).read_bytes() == b"pub fn demo() {}\n"
+
+
+def test_read_tar_gz_text_file_reads_matching_member() -> None:
+    archive_content = _tar_gz_with_files(
+        {
+            "crate/README.md": b"readme",
+            "crate/Cargo.toml": b'[package]\nname = "crate"\n',
+        }
+    )
+
+    result = read_tar_gz_text_file(archive_content, "/Cargo.toml")
+
+    assert result == '[package]\nname = "crate"\n'
+
+
+def test_read_tar_gz_text_file_returns_none_without_matching_member() -> None:
+    archive_content = _tar_gz_with_files({"crate/README.md": b"readme"})
+
+    result = read_tar_gz_text_file(archive_content, "/Cargo.toml")
+
+    assert result is None
+
+
+def test_read_tar_gz_text_file_rejects_oversized_member() -> None:
+    archive_content = _tar_gz_with_files({"crate/Cargo.toml": b"x" * 21})
+
+    with pytest.raises(ValueError, match="exceeds maximum size of 20 bytes"):
+        read_tar_gz_text_file(
+            archive_content,
+            "/Cargo.toml",
+            max_bytes=20,
+        )
+
+
+def test_read_tar_gz_text_file_accepts_exact_size_limit() -> None:
+    archive_content = _tar_gz_with_files({"crate/Cargo.toml": b"x" * 20})
+
+    result = read_tar_gz_text_file(
+        archive_content,
+        "/Cargo.toml",
+        max_bytes=20,
+    )
+
+    assert result == "x" * 20
+
+
+def test_read_tar_gz_text_file_rejects_invalid_size_limit() -> None:
+    with pytest.raises(ValueError, match="max_bytes must be greater than zero"):
+        read_tar_gz_text_file(b"archive", "/Cargo.toml", max_bytes=0)
+
+
+def test_read_tar_gz_text_file_rejects_invalid_member_limit() -> None:
+    with pytest.raises(ValueError, match="max_members must be greater than zero"):
+        read_tar_gz_text_file(b"archive", "/Cargo.toml", max_members=0)
+
+
+def test_read_tar_gz_text_file_rejects_too_many_members_before_match() -> None:
+    archive_content = _tar_gz_with_files(
+        {
+            "crate/README.md": b"readme",
+            "crate/Cargo.toml": b'[package]\nname = "crate"\n',
+        }
+    )
+
+    with pytest.raises(ValueError, match="Archive contains more than 1 members"):
+        read_tar_gz_text_file(archive_content, "/Cargo.toml", max_members=1)
+
+
+def test_read_tar_gz_text_file_rejects_large_unmatched_member_before_match() -> None:
+    archive_content = _tar_gz_with_files(
+        {
+            "crate/large.txt": b"x" * 10_000,
+            "crate/Cargo.toml": b'[package]\nname = "crate"\n',
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Archive exceeds maximum extracted size of 20 bytes",
+    ):
+        read_tar_gz_text_file(
+            archive_content,
+            "/Cargo.toml",
+            max_bytes=20,
+            max_members=2,
+        )
+
+
+def test_read_tar_gz_text_file_rejects_malformed_archive() -> None:
+    with pytest.raises(ValueError, match="Malformed gzip tar archive"):
+        read_tar_gz_text_file(b"not a gzip tar archive", "/Cargo.toml")
+
+
+def test_bounded_reader_rejects_decompressed_stream_over_budget() -> None:
+    compressed_content = gzip.compress(b"x" * 21)
+
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed_content)) as gzip_stream:
+        reader = _BoundedGzipReader(gzip_stream, max_bytes=20, max_content_bytes=20)
+        assert reader.readable()
+        assert reader.seekable()
+        with pytest.raises(
+            ValueError,
+            match="Archive exceeds maximum extracted size of 20 bytes",
+        ):
+            reader.read()
+
+
+def test_bounded_reader_caps_large_requested_read_before_delegating() -> None:
+    compressed_content = gzip.compress(b"x" * 10_000)
+
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed_content)) as gzip_stream:
+        reader = _BoundedGzipReader(gzip_stream, max_bytes=20, max_content_bytes=20)
+        with pytest.raises(
+            ValueError,
+            match="Archive exceeds maximum extracted size of 20 bytes",
+        ):
+            reader.read(10_000)
+
+        assert gzip_stream.tell() == 21
+
+
+def test_bounded_reader_rejects_when_already_over_budget() -> None:
+    compressed_content = gzip.compress(b"x" * 10)
+
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed_content)) as gzip_stream:
+        reader = _BoundedGzipReader(gzip_stream, max_bytes=1, max_content_bytes=1)
+        with pytest.raises(
+            ValueError,
+            match="Archive exceeds maximum extracted size of 1 bytes",
+        ):
+            reader.read(2)
+        with pytest.raises(
+            ValueError,
+            match="Archive exceeds maximum extracted size of 1 bytes",
+        ):
+            reader.read(1)
+
+
+def test_bounded_reader_caps_forward_seek_before_delegating() -> None:
+    compressed_content = gzip.compress(b"x" * 10_000)
+
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed_content)) as gzip_stream:
+        reader = _BoundedGzipReader(gzip_stream, max_bytes=20, max_content_bytes=20)
+        with pytest.raises(
+            ValueError,
+            match="Archive exceeds maximum extracted size of 20 bytes",
+        ):
+            reader.seek(10_000)
+
+        assert gzip_stream.tell() == 21
+
+
+def test_bounded_reader_supports_small_forward_and_backward_seeks() -> None:
+    compressed_content = gzip.compress(b"0123456789")
+
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed_content)) as gzip_stream:
+        reader = _BoundedGzipReader(gzip_stream, max_bytes=20, max_content_bytes=20)
+
+        assert reader.read(5) == b"01234"
+        assert reader.tell() == 5
+        assert reader.seek(8, io.SEEK_CUR) == 10
+        assert reader.tell() == 10
+        assert reader.seek(2) == 2
+        assert reader.tell() == 2
+
+
+def test_bounded_reader_stops_forward_seek_at_eof() -> None:
+    compressed_content = gzip.compress(b"abc")
+
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed_content)) as gzip_stream:
+        reader = _BoundedGzipReader(gzip_stream, max_bytes=20, max_content_bytes=20)
+
+        assert reader.seek(10) == 3
+
+
+@pytest.mark.parametrize("whence", [io.SEEK_END, 99])
+def test_bounded_reader_rejects_unsupported_seek_modes(whence: int) -> None:
+    compressed_content = gzip.compress(b"abc")
+
+    with gzip.GzipFile(fileobj=io.BytesIO(compressed_content)) as gzip_stream:
+        reader = _BoundedGzipReader(gzip_stream, max_bytes=20, max_content_bytes=20)
+
+        with pytest.raises(ValueError):
+            reader.seek(1, whence)
+
+
+def test_is_safe_tar_member_accepts_destination_member(tmp_path: Path) -> None:
+    member = tarfile.TarInfo("")
+    member.size = 0
+
+    assert _is_safe_tar_member(member, str(tmp_path))
+
+
+def test_is_safe_tar_member_rejects_unsafe_path(tmp_path: Path) -> None:
+    member = tarfile.TarInfo("../escape.txt")
+    member.size = 0
+
+    assert not _is_safe_tar_member(member, str(tmp_path))
+
+
+def test_decompression_budget_includes_tar_overhead() -> None:
+    assert _decompression_budget(1000, 3) == 1000 + 5 * 1024
+
+
+def test_archive_constants_are_pinned() -> None:
+    assert MAX_EXTRACTED_ARCHIVE_BYTES == 100 * 1024 * 1024
+    assert MAX_ARCHIVE_MEMBERS == 10_000


### PR DESCRIPTION
## Summary

This PR finishes the OSPO-53 hardening work for Rust crate archive handling.

What changed:

- Moved bounded HTTP download behavior out of `adaptors/os.py` into `utils/bounded_download.py`.
- Moved tar/gzip archive handling out of `adaptors/os.py` into `utils/tar_archive.py`.
- Reworked tar.gz processing to avoid `TarFile.getmembers()` and validate members lazily.
- Added a bounded gzip reader that caps delegated `read()` and forward `seek()` operations before calling into `gzip.GzipFile`, so skipped tar payloads and large unmatched members cannot inflate far beyond the decompression budget before enforcement.
- Kept `adaptors/os.py` as thin primitives for path helpers and streaming HTTP responses.
- Updated the Rust package resolver and crates.io metadata strategy to use the new utility modules and shared `DDLA_USER_AGENT`.

## Why

The previous implementation put substantial archive/download behavior in the OS adaptor and used `getmembers()`, which forces tarfile to walk the full archive before size/member limits are enforced. Review also caught that checking the gzip position after `read()` or `seek()` returned still allowed oversized decompression for skipped data, such as large PAX headers or non-matching members scanned before `/Cargo.toml`.

This PR makes the archive reader enforce the decompression budget at the wrapper boundary before delegating large operations to gzip.

## Tests

Validated locally:

- `pipenv run mypy src/ tests/`
- `pipenv run black --check src/ tests/ && pipenv run isort --check-only src/ tests/`
- `pipenv run ruff check src/ tests/`
- Focused unit suite: `tests/unit/test_os_adaptor.py`, `tests/unit/test_bounded_download.py`, `tests/unit/test_tar_archive.py`, `tests/unit/test_rust_package_resolver.py`, `tests/unit/test_rust_crates_io_collection_strategy.py`
- `pipenv run pytest tests/ --ignore=tests/contract/test_agithub.py --cov=src/dd_license_attribution --cov-fail-under=95` passed at 95.43% coverage.

The unexcluded `tests/` run reached 95.43% coverage but failed the five `tests/contract/test_agithub.py` cases because this environment denied Python socket connects to `api.github.com` with `PermissionError`.

End-to-end checks completed before the final review fix, against the same feature branch content except for the bounded-reader review patch:

- `dd-license-attribution generate-sbom --ecosystem rust --no-gh-auth ripgrep`
- `dd-license-attribution generate-sbom --ecosystem rust --no-gh-auth serde@1.0`

Both commands exited 0, produced parseable CSV output with real Rust dependency data, included the expected root rows, and did not include `ddla-rust-resolve`.

## Follow-up

Created OSPO-88 for two adjacent issues intentionally left out of OSPO-53 scope:

- quote crate names in the crates.io metadata URL path
- make `read_tar_gz_text_file()` match `Cargo.toml` under the expected crate root instead of the first suffix match in tar order
