### PR TITLE
chore(pypi): rename distribution to datadog-license-attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-11
+
 ### Added
 - New reusable composite GitHub Action (`action.yml` at the repository root) that regenerates a third-party license SBOM and validates it against a committed `LICENSE-3rdparty.csv` file. It sets up its own Python, Go, Node.js/npm/Yarn, and Rust/dd-rust-license-tool toolchains as needed, installs the pinned tool version, and takes the target as an `owner/name` `repository` input (defaulting to the current repository). It automatically builds a mirror so the branch actually under test (`pull_request` head, merge-queue, or pushed branch) is scanned; when `github-token` is provided, the mirror supports cloning **private repositories**. `pull_request_target` intentionally remains on the base branch to avoid exposing privileged tokens while scanning untrusted code. Additional inputs control `ecosystem`/`package`, the `csv-path` to compare, `--override-spec`, per-strategy enable/disable toggles including `rust-strategy`, `--experimental-strategy`, `--deep-scanning`, `--yarn-subdir`, the `default-branch`, the `github-token`, Python/Go/Node.js/Rust versions (each can be set to `false` to skip the internal toolchain setup when the calling workflow already provides it), and the exact-vs-structural `compare` mode; it exposes `sbom-path` and `matches` outputs. Callers with special needs can supply their own mirror-specification file via `use-mirrors`, whose entries are merged ahead of (and thus take precedence over) the auto-built mirror. Reference it as `DataDog/dd-license-attribution@<ref>`.
 - New `yarn-subdir` action input accepts newline-separated paths and forwards each path as a `--yarn-subdir` argument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The minimum supported Typer version is now 0.27.0.
 - Markdown `generate-sbom` reports now show the root package version explicitly, exclude the root package from the dependency table, and include root license and copyright in the summary.
 - PyPI collection strategy now performs case-insensitive key matching for project_urls dictionary to better handle different key capitalizations from PyPI metadata
+- PyPI package name is now `datadog-license-attribution` to follow Datadog's PyPI packaging conventions. The CLI command name (`dd-license-attribution`) is unchanged.
+- `authors` metadata in `pyproject.toml` now lists Datadog, Inc. instead of individual maintainers, and `project.urls` now also sets `Repository`.
 
 ### Deprecated
 - `generate-sbom-csv` is deprecated in favor of `generate-sbom --format csv`; it still works and emits a deprecation warning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,16 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "dd-license-attribution"
+name = "datadog-license-attribution"
 version = "0.5.0"
 description = "A tool that collects license and copyright information for third party dependencies of a project."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [
-    { name = "Damian Vicino", email = "damian.vicino@datadoghq.com" },
-    { name = "Ara Pulido", email = "ara.pulido@datadoghq.com" }
+    { name = "Datadog, Inc.", email = "package@datadoghq.com" }
 ]
-urls = { "Homepage" = "https://github.com/DataDog/dd-license-attribution" }
+urls = { "Homepage" = "https://github.com/DataDog/dd-license-attribution/blob/main/README.md", "Repository" = "https://github.com/DataDog/dd-license-attribution" }
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datadog-license-attribution"
-version = "0.5.0"
+version = "0.6.0"
 description = "A tool that collects license and copyright information for third party dependencies of a project."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dd_license_attribution/report_generator/writters/spdx_reporting_writter.py
+++ b/src/dd_license_attribution/report_generator/writters/spdx_reporting_writter.py
@@ -126,7 +126,7 @@ class SPDXReportingWritter(ReportingWritter):
 
 def _get_tool_version() -> str:
     try:
-        return version("dd-license-attribution")
+        return version("datadog-license-attribution")
     except PackageNotFoundError:
         return "unknown"
 

--- a/tests/unit/test_spdx_reporting_writter.py
+++ b/tests/unit/test_spdx_reporting_writter.py
@@ -230,4 +230,4 @@ def test_spdx_reporting_writter_uses_unknown_when_package_version_is_missing() -
         )
 
     assert spdx_report_writter.tool_version == "unknown"
-    mock_version.assert_called_once_with("dd-license-attribution")
+    mock_version.assert_called_once_with("datadog-license-attribution")


### PR DESCRIPTION
## Summary
- Rename the PyPI distribution to `datadog-license-attribution` to follow Datadog's PyPI packaging conventions (the CLI command `dd-license-attribution` is unchanged).
- Set `authors` to Datadog, Inc. and add `Repository` alongside `Homepage` in `project.urls`.
- Update the SPDX report writer's tool-version lookup (`importlib.metadata.version(...)`) to use the new distribution name, plus its test.
- Prepare the `0.6.0` release: bump `pyproject.toml` version and add a dated `[0.6.0]` CHANGELOG section.

## Test plan
- [x] `pytest tests/unit/test_spdx_reporting_writter.py` passes with 100% coverage of the touched module
- [x] `mypy src/ tests/`, `black --check`, `isort --check-only` all pass
- [x] Local `codex review --base main` and an independent Opus review pass both came back clean